### PR TITLE
fix type wrong for ep argument on usbd_ep_in_handler and usbd_ep_out_handler function

### DIFF
--- a/core/usbd_core.c
+++ b/core/usbd_core.c
@@ -1243,11 +1243,11 @@ void usbd_event_notify_handler(uint8_t event, void *arg)
             break;
 
         case USBD_EVENT_EP_IN_NOTIFY:
-            usbd_ep_in_handler((uint32_t)arg);
+            usbd_ep_in_handler((uint8_t)arg);
             break;
 
         case USBD_EVENT_EP_OUT_NOTIFY:
-            usbd_ep_out_handler((uint32_t)arg);
+            usbd_ep_out_handler((uint8_t)arg);
             break;
 
         default:


### PR DESCRIPTION
use uint8_t type to describe endpoint field.