### PR TITLE
修复./core/usbd_core.c以及./port/musb/usbd_dc_musb.c中的bug

### DIFF
--- a/core/usbd_core.c
+++ b/core/usbd_core.c
@@ -367,7 +367,7 @@ static bool usbd_std_device_req_handler(struct usb_setup_packet *setup, uint8_t 
         case USB_REQUEST_SET_FEATURE:
             if (value == USB_FEATURE_REMOTE_WAKEUP) {
             } else if (value == USB_FEATURE_TEST_MODE) {
-#ifdef CONFIG_USBDEV_TEST_MODE
+#if CONFIG_USBDEV_TEST_MODE
                 usbd_core_cfg.test_mode = true;
                 usbd_execute_test_mode(setup);
 #endif
@@ -894,6 +894,7 @@ void usbd_event_ep_out_complete_handler(uint8_t ep, uint32_t nbytes)
         struct usb_setup_packet *setup = &usbd_core_cfg.setup;
 
         if (nbytes > 0) {
+            memcpy(usbd_core_cfg.req_data, usbd_core_cfg.ep0_data_buf,  nbytes);
             usbd_core_cfg.ep0_data_buf += nbytes;
             usbd_core_cfg.ep0_data_buf_residue -= nbytes;
 


### PR DESCRIPTION
1. 修复./core/usbd_core.c中bug

- line 370，#ifdef CONFIG_USBDEV_TEST_MODE改为#if CONFIG_USBDEV_TEST_MODE
- line897，添加memcpy(usbd_core_cfg.req_data, usbd_core_cfg.ep0_data_buf,  nbytes)用于在循环读取数据时将数据备份到数组usbd_core_cfg.req_data中，以便数据读取结束后进行后续的请求处理。

2. 修复./port/musb/usbd_dc_musb.c中的bug

- 修复读8bit寄存器时按16bit读取的问题
- 删除对只读寄存器的写操作
- 优化中断程序的控制流程