### PR TITLE
update msub and usbd_core

### DIFF
--- a/core/usbd_core.h
+++ b/core/usbd_core.h
@@ -63,12 +63,13 @@ struct usbd_interface {
 };
 
 struct usb_descriptor {
-    const uint8_t *device_descriptor;
-    const uint8_t **fs_config_descriptor;
-    const uint8_t **hs_config_descriptor;
+    const uint8_t *device_descriptor;  
     const uint8_t *device_quality_descriptor;
-    const uint8_t *other_speed_descriptor;
-    const char **string_descriptor;
+    const uint8_t *config_descriptor_head;  
+    const uint8_t *other_speed_descriptor_head;
+    const uint8_t *fs_config_descriptor;
+    const uint8_t *hs_config_descriptor;
+    const uint8_t *string_descriptor;
     struct usb_msosv1_descriptor *msosv1_descriptor;
     struct usb_msosv2_descriptor *msosv2_descriptor;
     struct usb_bos_descriptor *bos_descriptor;


### PR DESCRIPTION
1. add the function to read and write packet in poll mode in the musb/usb_dc_musb.c,  the reason why this change is that the irq flag may be cleared mistakely under the condition of stress test or large data arrive.
2. update the usbd_core.c and usbd_core.h to achieve the feature, change device speed mode automatically and response the correct descriptor to host accoding to the hub speed which device plug in.