### PR TITLE
Use marco usb_memcpy and usb_memset for memcpy and memset

### DIFF
--- a/cherryusb_config_template.h
+++ b/cherryusb_config_template.h
@@ -14,6 +14,8 @@
 
 #define usb_malloc(size) malloc(size)
 #define usb_free(ptr)    free(ptr)
+#define usb_memcpy(dst, src, size) memcpy(dst, src, size)
+#define usb_memset(ptr, c, size) memset(ptr, c, size)
 
 #ifndef CONFIG_USB_DBG_LEVEL
 #define CONFIG_USB_DBG_LEVEL USB_DBG_INFO

--- a/class/audio/usbd_audio.c
+++ b/class/audio/usbd_audio.c
@@ -62,7 +62,7 @@ static int audio_class_endpoint_request_handler(struct usb_setup_packet *setup, 
             case AUDIO_REQUEST_SET_CUR:
                 switch (control_selector) {
                     case AUDIO_EP_CONTROL_SAMPLING_FEQ:
-                        memcpy((uint8_t *)&sampling_freq, *data, *len);
+                        usb_memcpy((uint8_t *)&sampling_freq, *data, *len);
                         USB_LOG_DBG("Set ep:%02x %d Hz\r\n", ep, (int)sampling_freq);
                         usbd_audio_set_sampling_freq(0, ep, sampling_freq);
                         break;
@@ -77,7 +77,7 @@ static int audio_class_endpoint_request_handler(struct usb_setup_packet *setup, 
                 break;
             case AUDIO_REQUEST_GET_CUR:
                 sampling_freq = 16000;
-                memcpy(*data, &sampling_freq, 4);
+                usb_memcpy(*data, &sampling_freq, 4);
                 *len = 4;
                 USB_LOG_DBG("Get ep:%02x %d Hz\r\n", ep, (int)sampling_freq);
                 break;
@@ -175,27 +175,27 @@ static int audio_class_interface_request_handler(struct usb_setup_packet *setup,
                         usbd_audio_set_volume(entity_id, ch, volume2db);
                         break;
                     case AUDIO_REQUEST_GET_CUR:
-                        memcpy(*data, &current_feature_control->volume[ch].vol_current, 2);
+                        usb_memcpy(*data, &current_feature_control->volume[ch].vol_current, 2);
                         *len = 2;
                         break;
 
                     case AUDIO_REQUEST_GET_MIN:
-                        memcpy(*data, &current_feature_control->volume[ch].vol_min, 2);
+                        usb_memcpy(*data, &current_feature_control->volume[ch].vol_min, 2);
                         *len = 2;
                         break;
 
                     case AUDIO_REQUEST_GET_MAX:
-                        memcpy(*data, &current_feature_control->volume[ch].vol_max, 2);
+                        usb_memcpy(*data, &current_feature_control->volume[ch].vol_max, 2);
                         *len = 2;
                         break;
 
                     case AUDIO_REQUEST_GET_RES:
-                        memcpy(*data, &current_feature_control->volume[ch].vol_res, 2);
+                        usb_memcpy(*data, &current_feature_control->volume[ch].vol_res, 2);
                         *len = 2;
                         break;
 
                     case AUDIO_REQUEST_SET_RES:
-                        memcpy(&current_feature_control->volume[ch].vol_res, *data, 2);
+                        usb_memcpy(&current_feature_control->volume[ch].vol_res, *data, 2);
                         *len = 2;
                         break;
                     default:
@@ -270,11 +270,11 @@ static int audio_class_interface_request_handler(struct usb_setup_packet *setup,
                 switch (control_selector) {
                     case AUDIO_CS_CONTROL_SAM_FREQ:
                         if (setup->bmRequestType & USB_REQUEST_DIR_MASK) {
-                            memcpy(*data, &sampling_freq[ch], sizeof(uint32_t));
+                            usb_memcpy(*data, &sampling_freq[ch], sizeof(uint32_t));
                             USB_LOG_DBG("Get ClockId:%d ch[%d] %d Hz\r\n", entity_id, ch, (int)sampling_freq[ch]);
                             *len = 4;
                         } else {
-                            memcpy(&sampling_freq[ch], *data, setup->wLength);
+                            usb_memcpy(&sampling_freq[ch], *data, setup->wLength);
                             USB_LOG_DBG("Set ClockId:%d ch[%d] %d Hz\r\n", entity_id, ch, (int)sampling_freq[ch]);
                             usbd_audio_set_sampling_freq(entity_id, ch, sampling_freq[ch]);
                         }
@@ -300,7 +300,7 @@ static int audio_class_interface_request_handler(struct usb_setup_packet *setup,
 
                             usbd_audio_get_sampling_freq_table(entity_id, &sampling_freq_table);
                             num = (uint16_t)((uint16_t)(sampling_freq_table[1] << 8) | ((uint16_t)sampling_freq_table[0]));
-                            memcpy(*data, sampling_freq_table, (12 * num + 2));
+                            usb_memcpy(*data, sampling_freq_table, (12 * num + 2));
                             *len = (12 * num + 2);
                             USB_LOG_DBG("Get sampling_freq_table entity_id:%d ch[%d] addr:%x\r\n", entity_id, ch, (uint32_t)sampling_freq_table);
                         } else {
@@ -364,14 +364,14 @@ struct usbd_interface *usbd_audio_init_intf(struct usbd_interface *intf)
 void usbd_audio_add_entity(uint8_t entity_id, uint16_t bDescriptorSubtype)
 {
     struct audio_entity_info *entity_info = usb_malloc(sizeof(struct audio_entity_info));
-    memset(entity_info, 0, sizeof(struct audio_entity_info));
+    usb_memset(entity_info, 0, sizeof(struct audio_entity_info));
     entity_info->bEntityId = entity_id;
     entity_info->bDescriptorSubtype = bDescriptorSubtype;
 
     if (bDescriptorSubtype == AUDIO_CONTROL_FEATURE_UNIT) {
 #if CONFIG_USBDEV_AUDIO_VERSION < 0x0200
         struct usbd_audio_attribute_control *control = usb_malloc(sizeof(struct usbd_audio_attribute_control));
-        memset(control, 0, sizeof(struct usbd_audio_attribute_control));
+        usb_memset(control, 0, sizeof(struct usbd_audio_attribute_control));
         for (uint8_t ch = 0; ch < CONFIG_USBDEV_AUDIO_MAX_CHANNEL; ch++) {
             control->volume[ch].vol_min = 0xdb00;
             control->volume[ch].vol_max = 0x0000;
@@ -382,7 +382,7 @@ void usbd_audio_add_entity(uint8_t entity_id, uint16_t bDescriptorSubtype)
         }
 #else
         struct usbd_audio_attribute_control *control = usb_malloc(sizeof(struct usbd_audio_attribute_control));
-        memset(control, 0, sizeof(struct usbd_audio_attribute_control));
+        usb_memset(control, 0, sizeof(struct usbd_audio_attribute_control));
         for (uint8_t ch = 0; ch < CONFIG_USBDEV_AUDIO_MAX_CHANNEL; ch++) {
             control->volume.wNumSubRanges = 1;
             control->volume.subrange[ch].wMin = 0;

--- a/class/audio/usbh_audio.c
+++ b/class/audio/usbh_audio.c
@@ -97,7 +97,7 @@ freq_found:
     setup->wIndex = ep_desc->bEndpointAddress;
     setup->wLength = 3;
 
-    memcpy(g_audio_buf, &samp_freq, 3);
+    usb_memcpy(g_audio_buf, &samp_freq, 3);
     ret = usbh_control_transfer(audio_class->hport->ep0, setup, g_audio_buf);
     if (ret < 0) {
         return ret;
@@ -190,7 +190,7 @@ int usbh_audio_set_volume(struct usbh_audio *audio_class, const char *name, uint
 
     volume_hex = -0xDB00 / 100 * volume + 0xdb00;
 
-    memcpy(g_audio_buf, &volume_hex, 2);
+    usb_memcpy(g_audio_buf, &volume_hex, 2);
     ret = usbh_control_transfer(audio_class->hport->ep0, setup, NULL);
 
     return ret;
@@ -220,7 +220,7 @@ int usbh_audio_set_mute(struct usbh_audio *audio_class, const char *name, uint8_
     setup->wIndex = (feature_id << 8) | intf;
     setup->wLength = 1;
 
-    memcpy(g_audio_buf, &mute, 1);
+    usb_memcpy(g_audio_buf, &mute, 1);
     ret = usbh_control_transfer(audio_class->hport->ep0, setup, g_audio_buf);
     
     return ret;
@@ -275,7 +275,7 @@ static int usbh_audio_ctrl_connect(struct usbh_hubport *hport, uint8_t intf)
         return -ENOMEM;
     }
 
-    memset(audio_class, 0, sizeof(struct usbh_audio));
+    usb_memset(audio_class, 0, sizeof(struct usbh_audio));
     usbh_audio_devno_alloc(audio_class);
     audio_class->hport = hport;
     audio_class->ctrl_intf = intf;
@@ -423,7 +423,7 @@ static int usbh_audio_ctrl_disconnect(struct usbh_hubport *hport, uint8_t intf)
         }
 
         usbh_audio_stop(audio_class);
-        memset(audio_class, 0, sizeof(struct usbh_audio));
+        usb_memset(audio_class, 0, sizeof(struct usbh_audio));
         usb_free(audio_class);
 
         if (hport->config.intf[intf].devname[0] != '\0')

--- a/class/cdc/usbd_cdc.c
+++ b/class/cdc/usbd_cdc.c
@@ -39,7 +39,7 @@ static int cdc_acm_class_interface_request_handler(struct usb_setup_packet *setu
             /*                                        4 - Space                            */
             /* 6      | bDataBits  |   1   | Number Data bits (5, 6, 7, 8 or 16).          */
             /*******************************************************************************/
-            memcpy(&line_coding, *data, setup->wLength);
+            usb_memcpy(&line_coding, *data, setup->wLength);
             USB_LOG_DBG("Set intf:%d linecoding <%d %d %s %s>\r\n",
                         intf_num,
                         line_coding.dwDTERate,
@@ -62,7 +62,7 @@ static int cdc_acm_class_interface_request_handler(struct usb_setup_packet *setu
 
         case CDC_REQUEST_GET_LINE_CODING:
             usbd_cdc_acm_get_line_coding(intf_num, &line_coding);
-            memcpy(*data, &line_coding, 7);
+            usb_memcpy(*data, &line_coding, 7);
             *len = 7;
             USB_LOG_DBG("Get intf:%d linecoding %d %d %d %d\r\n",
                         intf_num,

--- a/class/cdc/usbh_cdc_acm.c
+++ b/class/cdc/usbh_cdc_acm.c
@@ -46,7 +46,7 @@ int usbh_cdc_acm_set_line_coding(struct usbh_cdc_acm *cdc_acm_class, struct cdc_
     setup->wIndex = cdc_acm_class->ctrl_intf;
     setup->wLength = 7;
 
-    memcpy((uint8_t *)&g_cdc_line_coding, line_coding, sizeof(struct cdc_line_coding));
+    usb_memcpy((uint8_t *)&g_cdc_line_coding, line_coding, sizeof(struct cdc_line_coding));
 
     return usbh_control_transfer(cdc_acm_class->hport->ep0, setup, (uint8_t *)&g_cdc_line_coding);
 }
@@ -66,7 +66,7 @@ int usbh_cdc_acm_get_line_coding(struct usbh_cdc_acm *cdc_acm_class, struct cdc_
     if (ret < 0) {
         return ret;
     }
-    memcpy(line_coding, (uint8_t *)&g_cdc_line_coding, sizeof(struct cdc_line_coding));
+    usb_memcpy(line_coding, (uint8_t *)&g_cdc_line_coding, sizeof(struct cdc_line_coding));
     return ret;
 }
 
@@ -97,7 +97,7 @@ static int usbh_cdc_acm_connect(struct usbh_hubport *hport, uint8_t intf)
         return -ENOMEM;
     }
 
-    memset(cdc_acm_class, 0, sizeof(struct usbh_cdc_acm));
+    usb_memset(cdc_acm_class, 0, sizeof(struct usbh_cdc_acm));
     usbh_cdc_acm_devno_alloc(cdc_acm_class);
     cdc_acm_class->hport = hport;
     cdc_acm_class->ctrl_intf = intf;
@@ -168,7 +168,7 @@ static int usbh_cdc_acm_disconnect(struct usbh_hubport *hport, uint8_t intf)
         }
 
         usbh_cdc_acm_stop(cdc_acm_class);
-        memset(cdc_acm_class, 0, sizeof(struct usbh_cdc_acm));
+        usb_memset(cdc_acm_class, 0, sizeof(struct usbh_cdc_acm));
         usb_free(cdc_acm_class);
 
         if (hport->config.intf[intf].devname[0] != '\0')

--- a/class/dfu/usbd_dfu.c
+++ b/class/dfu/usbd_dfu.c
@@ -44,7 +44,7 @@ struct dfu_cfg_priv {
 
 static void dfu_reset(void)
 {
-    memset(&usbd_dfu_cfg, 0, sizeof(usbd_dfu_cfg));
+    usb_memset(&usbd_dfu_cfg, 0, sizeof(usbd_dfu_cfg));
 
     usbd_dfu_cfg.alt_setting = 0U;
     usbd_dfu_cfg.data_ptr = USBD_DFU_APP_DEFAULT_ADD;
@@ -130,7 +130,7 @@ static void dfu_request_upload(struct usb_setup_packet *setup, uint8_t **data, u
                 usbd_dfu_cfg.buffer.d8[2] = DFU_CMD_ERASE;
 
                 /* Send the status data over EP0 */
-                memcpy(*data, usbd_dfu_cfg.buffer.d8, 3);
+                usb_memcpy(*data, usbd_dfu_cfg.buffer.d8, 3);
                 *len = 3;
             } else if (usbd_dfu_cfg.wblock_num > 1U) {
                 usbd_dfu_cfg.dev_state = DFU_STATE_DFU_UPLOAD_IDLE;
@@ -146,7 +146,7 @@ static void dfu_request_upload(struct usb_setup_packet *setup, uint8_t **data, u
                 phaddr = dfu_read_flash((uint8_t *)addr, usbd_dfu_cfg.buffer.d8, usbd_dfu_cfg.wlength);
 
                 /* Send the status data over EP0 */
-                memcpy(*data, usbd_dfu_cfg.buffer.d8, usbd_dfu_cfg.wlength);
+                usb_memcpy(*data, usbd_dfu_cfg.buffer.d8, usbd_dfu_cfg.wlength);
                 *len = usbd_dfu_cfg.wlength;
             } else /* unsupported usbd_dfu_cfg.wblock_num */
             {
@@ -196,7 +196,7 @@ static void dfu_request_dnload(struct usb_setup_packet *setup, uint8_t **data, u
             usbd_dfu_cfg.dev_status[4] = usbd_dfu_cfg.dev_state;
 
             /*!< Data has received complete */
-            memcpy((uint8_t *)usbd_dfu_cfg.buffer.d8, (uint8_t *)*data, usbd_dfu_cfg.wlength);
+            usb_memcpy((uint8_t *)usbd_dfu_cfg.buffer.d8, (uint8_t *)*data, usbd_dfu_cfg.wlength);
             /*!< Set flag = 1 Write the firmware to the flash in the next dfu_request_getstatus */
             usbd_dfu_cfg.firmwar_flag = 1;
         }
@@ -369,7 +369,7 @@ static void dfu_request_getstatus(struct usb_setup_packet *setup, uint8_t **data
     }
 
     /* Send the status data over EP0 */
-    memcpy(*data, usbd_dfu_cfg.dev_status, 6);
+    usb_memcpy(*data, usbd_dfu_cfg.dev_status, 6);
     *len = 6;
 
     if (usbd_dfu_cfg.firmwar_flag == 1) {

--- a/class/hid/usbh_hid.c
+++ b/class/hid/usbh_hid.c
@@ -52,7 +52,7 @@ static int usbh_hid_get_report_descriptor(struct usbh_hid *hid_class, uint8_t *b
     if (ret < 0) {
         return ret;
     }
-    memcpy(buffer, g_hid_buf, ret - 8);
+    usb_memcpy(buffer, g_hid_buf, ret - 8);
     return ret;
 }
 
@@ -84,7 +84,7 @@ int usbh_hid_get_idle(struct usbh_hid *hid_class, uint8_t *buffer)
     if (ret < 0) {
         return ret;
     }
-    memcpy(buffer, g_hid_buf, 1);
+    usb_memcpy(buffer, g_hid_buf, 1);
     return ret;
 }
 
@@ -112,7 +112,7 @@ int usbh_hid_connect(struct usbh_hubport *hport, uint8_t intf)
         return -ENOMEM;
     }
 
-    memset(hid_class, 0, sizeof(struct usbh_hid));
+    usb_memset(hid_class, 0, sizeof(struct usbh_hid));
     usbh_hid_devno_alloc(hid_class);
     hid_class->hport = hport;
     hid_class->intf = intf;
@@ -170,7 +170,7 @@ int usbh_hid_disconnect(struct usbh_hubport *hport, uint8_t intf)
         }
 
         usbh_hid_stop(hid_class);
-        memset(hid_class, 0, sizeof(struct usbh_hid));
+        usb_memset(hid_class, 0, sizeof(struct usbh_hid));
         usb_free(hid_class);
 
         if (hport->config.intf[intf].devname[0] != '\0')

--- a/class/hub/usbh_hub.c
+++ b/class/hub/usbh_hub.c
@@ -106,7 +106,7 @@ static int _usbh_hub_get_hub_descriptor(struct usbh_hub *hub, uint8_t *buffer)
     if (ret < 0) {
         return ret;
     }
-    memcpy(buffer, g_hub_buf, USB_SIZEOF_HUB_DESC);
+    usb_memcpy(buffer, g_hub_buf, USB_SIZEOF_HUB_DESC);
     return ret;
 }
 
@@ -127,7 +127,7 @@ static int _usbh_hub_get_status(struct usbh_hub *hub, uint8_t *buffer)
     if (ret < 0) {
         return ret;
     }
-    memcpy(buffer, g_hub_buf, 2);
+    usb_memcpy(buffer, g_hub_buf, 2);
     return ret;
 }
 #endif
@@ -149,7 +149,7 @@ static int _usbh_hub_get_portstatus(struct usbh_hub *hub, uint8_t port, struct h
     if (ret < 0) {
         return ret;
     }
-    memcpy(port_status, g_hub_buf, 4);
+    usb_memcpy(port_status, g_hub_buf, 4);
     return ret;
 }
 
@@ -320,7 +320,7 @@ static int usbh_hub_connect(struct usbh_hubport *hport, uint8_t intf)
 
     struct usbh_hub *hub = &exthub[index - EXTHUB_FIRST_INDEX];
 
-    memset(hub, 0, sizeof(struct usbh_hub));
+    usb_memset(hub, 0, sizeof(struct usbh_hub));
     hub->hub_addr = hport->dev_addr;
     hub->parent = hport;
     hub->index = index;
@@ -414,7 +414,7 @@ static int usbh_hub_disconnect(struct usbh_hubport *hport, uint8_t intf)
         }
 
         usbh_hub_unregister(hub);
-        memset(hub, 0, sizeof(struct usbh_hub));
+        usb_memset(hub, 0, sizeof(struct usbh_hub));
 
         if (hport->config.intf[intf].devname[0] != '\0')
             USB_LOG_INFO("Unregister HUB Class:%s\r\n", hport->config.intf[intf].devname);
@@ -589,7 +589,7 @@ static void usbh_hub_events(struct usbh_hub *hub)
                     /** release child sources first */
                     usbh_hubport_release(child);
 
-                    memset(child, 0, sizeof(struct usbh_hubport));
+                    usb_memset(child, 0, sizeof(struct usbh_hubport));
                     child->parent = hub;
                     child->connected = true;
                     child->port = port + 1;
@@ -648,7 +648,7 @@ static void usbh_hub_thread(void *argument)
 
 static void usbh_roothub_register(void)
 {
-    memset(&roothub, 0, sizeof(struct usbh_hub));
+    usb_memset(&roothub, 0, sizeof(struct usbh_hub));
 
     roothub.connected = true;
     roothub.index = 1;

--- a/class/msc/usbd_msc.c
+++ b/class/msc/usbd_msc.c
@@ -217,7 +217,7 @@ static bool SCSI_requestSense(uint8_t **data, uint32_t *len)
     request_sense[13] = 0x00;         /* Additional Sense Code Qualifier */
 #endif
 
-    memcpy(*data, (uint8_t *)request_sense, data_len);
+    usb_memcpy(*data, (uint8_t *)request_sense, data_len);
     *len = data_len;
     return true;
 }
@@ -265,9 +265,9 @@ static bool SCSI_inquiry(uint8_t **data, uint32_t *len)
         ' ', ' ', ' ', ' ' /* Version      : 4 Bytes */
     };
 
-    memcpy(&inquiry[8], CONFIG_USBDEV_MSC_MANUFACTURER_STRING, strlen(CONFIG_USBDEV_MSC_MANUFACTURER_STRING));
-    memcpy(&inquiry[16], CONFIG_USBDEV_MSC_PRODUCT_STRING, strlen(CONFIG_USBDEV_MSC_PRODUCT_STRING));
-    memcpy(&inquiry[32], CONFIG_USBDEV_MSC_VERSION_STRING, strlen(CONFIG_USBDEV_MSC_VERSION_STRING));
+    usb_memcpy(&inquiry[8], CONFIG_USBDEV_MSC_MANUFACTURER_STRING, strlen(CONFIG_USBDEV_MSC_MANUFACTURER_STRING));
+    usb_memcpy(&inquiry[16], CONFIG_USBDEV_MSC_PRODUCT_STRING, strlen(CONFIG_USBDEV_MSC_PRODUCT_STRING));
+    usb_memcpy(&inquiry[32], CONFIG_USBDEV_MSC_VERSION_STRING, strlen(CONFIG_USBDEV_MSC_VERSION_STRING));
 
     if (usbd_msc_cfg.cbw.dDataLength == 0U) {
         SCSI_SetSenseData(SCSI_KCQIR_INVALIDCOMMAND);
@@ -277,10 +277,10 @@ static bool SCSI_inquiry(uint8_t **data, uint32_t *len)
     if ((usbd_msc_cfg.cbw.CB[1] & 0x01U) != 0U) { /* Evpd is set */
         if (usbd_msc_cfg.cbw.CB[2] == 0U) {       /* Request for Supported Vital Product Data Pages*/
             data_len = 0x06;
-            memcpy(*data, (uint8_t *)inquiry00, data_len);
+            usb_memcpy(*data, (uint8_t *)inquiry00, data_len);
         } else if (usbd_msc_cfg.cbw.CB[2] == 0x80U) { /* Request for VPD page 0x80 Unit Serial Number */
             data_len = 0x08;
-            memcpy(*data, (uint8_t *)inquiry80, data_len);
+            usb_memcpy(*data, (uint8_t *)inquiry80, data_len);
         } else { /* Request Not supported */
             SCSI_SetSenseData(SCSI_KCQIR_INVALIDFIELDINCBA);
             return false;
@@ -289,7 +289,7 @@ static bool SCSI_inquiry(uint8_t **data, uint32_t *len)
         if (usbd_msc_cfg.cbw.CB[4] < SCSIRESP_INQUIRY_SIZEOF) {
             data_len = usbd_msc_cfg.cbw.CB[4];
         }
-        memcpy(*data, (uint8_t *)inquiry, data_len);
+        usb_memcpy(*data, (uint8_t *)inquiry, data_len);
     }
 
     *len = data_len;
@@ -352,7 +352,7 @@ static bool SCSI_modeSense6(uint8_t **data, uint32_t *len)
     if (usbd_msc_cfg.readonly) {
         sense6[2] = 0x80;
     }
-    memcpy(*data, (uint8_t *)sense6, data_len);
+    usb_memcpy(*data, (uint8_t *)sense6, data_len);
     *len = data_len;
     return true;
 }
@@ -399,7 +399,7 @@ static bool SCSI_modeSense10(uint8_t **data, uint32_t *len)
         0x00
     };
 
-    memcpy(*data, (uint8_t *)sense10, data_len);
+    usb_memcpy(*data, (uint8_t *)sense10, data_len);
     *len = data_len;
     return true;
 }
@@ -426,7 +426,7 @@ static bool SCSI_readFormatCapacity(uint8_t **data, uint32_t *len)
         (uint8_t)((usbd_msc_cfg.scsi_blk_size >> 0) & 0xff),
     };
 
-    memcpy(*data, (uint8_t *)format_capacity, SCSIRESP_READFORMATCAPACITIES_SIZEOF);
+    usb_memcpy(*data, (uint8_t *)format_capacity, SCSIRESP_READFORMATCAPACITIES_SIZEOF);
     *len = SCSIRESP_READFORMATCAPACITIES_SIZEOF;
     return true;
 }
@@ -450,7 +450,7 @@ static bool SCSI_readCapacity10(uint8_t **data, uint32_t *len)
         (uint8_t)((usbd_msc_cfg.scsi_blk_size >> 0) & 0xff),
     };
 
-    memcpy(*data, (uint8_t *)capacity10, SCSIRESP_READCAPACITY10_SIZEOF);
+    usb_memcpy(*data, (uint8_t *)capacity10, SCSIRESP_READCAPACITY10_SIZEOF);
     *len = SCSIRESP_READCAPACITY10_SIZEOF;
     return true;
 }
@@ -823,7 +823,7 @@ struct usbd_interface *usbd_msc_init_intf(struct usbd_interface *intf, const uin
     usbd_add_endpoint(&mass_ep_data[MSD_OUT_EP_IDX]);
     usbd_add_endpoint(&mass_ep_data[MSD_IN_EP_IDX]);
 
-    memset((uint8_t *)&usbd_msc_cfg, 0, sizeof(struct usbd_msc_cfg_priv));
+    usb_memset((uint8_t *)&usbd_msc_cfg, 0, sizeof(struct usbd_msc_cfg_priv));
 
     usbd_msc_get_cap(0, &usbd_msc_cfg.scsi_blk_nbr, &usbd_msc_cfg.scsi_blk_size);
 

--- a/class/msc/usbh_msc.c
+++ b/class/msc/usbh_msc.c
@@ -85,7 +85,7 @@ static inline int usbh_msc_bulk_in_transfer(struct usbh_msc *msc_class, uint8_t 
 {
     int ret;
     struct usbh_urb *urb = &msc_class->bulkin_urb;
-    memset(urb, 0, sizeof(struct usbh_urb));
+    usb_memset(urb, 0, sizeof(struct usbh_urb));
 
     usbh_bulk_urb_fill(urb, msc_class->bulkin, buffer, buflen, timeout, NULL, NULL);
     ret = usbh_submit_urb(urb);
@@ -99,7 +99,7 @@ static inline int usbh_msc_bulk_out_transfer(struct usbh_msc *msc_class, uint8_t
 {
     int ret;
     struct usbh_urb *urb = &msc_class->bulkout_urb;
-    memset(urb, 0, sizeof(struct usbh_urb));
+    usb_memset(urb, 0, sizeof(struct usbh_urb));
 
     usbh_bulk_urb_fill(urb, msc_class->bulkout, buffer, buflen, timeout, NULL, NULL);
     ret = usbh_submit_urb(urb);
@@ -143,7 +143,7 @@ int usbh_bulk_cbw_csw_xfer(struct usbh_msc *msc_class, struct CBW *cbw, struct C
     }
 
     /* Receive the CSW */
-    memset(csw, 0, USB_SIZEOF_MSC_CSW);
+    usb_memset(csw, 0, USB_SIZEOF_MSC_CSW);
     nbytes = usbh_msc_bulk_in_transfer(msc_class, (uint8_t *)csw, USB_SIZEOF_MSC_CSW, CONFIG_USBHOST_MSC_TIMEOUT);
     if (nbytes < 0) {
         USB_LOG_ERR("csw transfer error\r\n");
@@ -172,7 +172,7 @@ static inline int usbh_msc_scsi_testunitready(struct usbh_msc *msc_class)
 
     /* Construct the CBW */
     cbw = (struct CBW *)g_msc_buf;
-    memset(cbw, 0, USB_SIZEOF_MSC_CBW);
+    usb_memset(cbw, 0, USB_SIZEOF_MSC_CBW);
     cbw->dSignature = MSC_CBW_Signature;
 
     cbw->bCBLength = SCSICMD_TESTUNITREADY_SIZEOF;
@@ -187,7 +187,7 @@ static inline int usbh_msc_scsi_requestsense(struct usbh_msc *msc_class)
 
     /* Construct the CBW */
     cbw = (struct CBW *)g_msc_buf;
-    memset(cbw, 0, USB_SIZEOF_MSC_CBW);
+    usb_memset(cbw, 0, USB_SIZEOF_MSC_CBW);
     cbw->dSignature = MSC_CBW_Signature;
 
     cbw->bmFlags = 0x80;
@@ -205,7 +205,7 @@ static inline int usbh_msc_scsi_inquiry(struct usbh_msc *msc_class)
 
     /* Construct the CBW */
     cbw = (struct CBW *)g_msc_buf;
-    memset(cbw, 0, USB_SIZEOF_MSC_CBW);
+    usb_memset(cbw, 0, USB_SIZEOF_MSC_CBW);
     cbw->dSignature = MSC_CBW_Signature;
 
     cbw->dDataLength = SCSIRESP_INQUIRY_SIZEOF;
@@ -223,7 +223,7 @@ static inline int usbh_msc_scsi_readcapacity10(struct usbh_msc *msc_class)
 
     /* Construct the CBW */
     cbw = (struct CBW *)g_msc_buf;
-    memset(cbw, 0, USB_SIZEOF_MSC_CBW);
+    usb_memset(cbw, 0, USB_SIZEOF_MSC_CBW);
     cbw->dSignature = MSC_CBW_Signature;
 
     cbw->dDataLength = SCSIRESP_READCAPACITY10_SIZEOF;
@@ -240,7 +240,7 @@ int usbh_msc_scsi_write10(struct usbh_msc *msc_class, uint32_t start_sector, con
 
     /* Construct the CBW */
     cbw = (struct CBW *)g_msc_buf;
-    memset(cbw, 0, USB_SIZEOF_MSC_CBW);
+    usb_memset(cbw, 0, USB_SIZEOF_MSC_CBW);
     cbw->dSignature = MSC_CBW_Signature;
 
     cbw->dDataLength = (msc_class->blocksize * nsectors);
@@ -259,7 +259,7 @@ int usbh_msc_scsi_read10(struct usbh_msc *msc_class, uint32_t start_sector, cons
 
     /* Construct the CBW */
     cbw = (struct CBW *)g_msc_buf;
-    memset(cbw, 0, USB_SIZEOF_MSC_CBW);
+    usb_memset(cbw, 0, USB_SIZEOF_MSC_CBW);
     cbw->dSignature = MSC_CBW_Signature;
 
     cbw->dDataLength = (msc_class->blocksize * nsectors);
@@ -284,7 +284,7 @@ static int usbh_msc_connect(struct usbh_hubport *hport, uint8_t intf)
         return -ENOMEM;
     }
 
-    memset(msc_class, 0, sizeof(struct usbh_msc));
+    usb_memset(msc_class, 0, sizeof(struct usbh_msc));
     usbh_msc_devno_alloc(msc_class);
     msc_class->hport = hport;
     msc_class->intf = intf;
@@ -360,7 +360,7 @@ static int usbh_msc_disconnect(struct usbh_hubport *hport, uint8_t intf)
         }
 
         usbh_msc_stop(msc_class);
-        memset(msc_class, 0, sizeof(struct usbh_msc));
+        usb_memset(msc_class, 0, sizeof(struct usbh_msc));
         usb_free(msc_class);
 
         if (hport->config.intf[intf].devname[0] != '\0')

--- a/class/mtp/usbd_mtp.c
+++ b/class/mtp/usbd_mtp.c
@@ -92,7 +92,7 @@ static void usbd_mtp_send_info(uint8_t *data, uint32_t len)
     g_usbd_mtp.con_data.code = MTP_RESPONSE_OK;
     g_usbd_mtp.con_data.trans_id = g_usbd_mtp.con_command.trans_id;
 
-    memcpy(g_usbd_mtp.con_data.data, data, len);
+    usb_memcpy(g_usbd_mtp.con_data.data, data, len);
     usbd_ep_start_write(mtp_ep_data[MTP_IN_EP_IDX].ep_addr, (uint8_t *)&g_usbd_mtp.con_data, 12 + len);
 }
 
@@ -228,7 +228,7 @@ static void usbd_mtp_get_object_info(void)
 
     /* we have to get this value before object_info.Filename */
     object_info.Filename_len = sizeof(DefaultFileName);
-    memcpy(object_info.Filename, DefaultFileName, (uint32_t)object_info.Filename_len + 1U);
+    usb_memcpy(object_info.Filename, DefaultFileName, (uint32_t)object_info.Filename_len + 1U);
 
     object_info.CaptureDate = 0U;
     object_info.ModificationDate = 0U;

--- a/class/mtp/usbh_mtp.c
+++ b/class/mtp/usbh_mtp.c
@@ -20,7 +20,7 @@ static int usbh_mtp_connect(struct usbh_hubport *hport, uint8_t intf)
         return -ENOMEM;
     }
 
-    memset(mtp_class, 0, sizeof(struct usbh_mtp));
+    usb_memset(mtp_class, 0, sizeof(struct usbh_mtp));
 
     mtp_class->hport = hport;
     mtp_class->ctrl_intf = intf;
@@ -82,7 +82,7 @@ static int usbh_mtp_disconnect(struct usbh_hubport *hport, uint8_t intf)
         if (hport->config.intf[intf].devname[0] != '\0')
             USB_LOG_INFO("Unregister MTP Class:%s\r\n", hport->config.intf[intf].devname);
 
-        memset(hport->config.intf[intf].devname, 0, CONFIG_USBHOST_DEV_NAMELEN);
+        usb_memset(hport->config.intf[intf].devname, 0, CONFIG_USBHOST_DEV_NAMELEN);
         hport->config.intf[intf].priv = NULL;
         hport->config.intf[intf + 1].priv = NULL;
     }

--- a/class/printer/usbd_printer.c
+++ b/class/printer/usbd_printer.c
@@ -20,7 +20,7 @@ static int printer_class_interface_request_handler(struct usb_setup_packet *setu
 
     switch (setup->bRequest) {
         case PRINTER_REQUEST_GET_DEVICE_ID:
-            memcpy(*data, usbd_printer_cfg.device_id, usbd_printer_cfg.device_id_len);
+            usb_memcpy(*data, usbd_printer_cfg.device_id, usbd_printer_cfg.device_id_len);
             *len = usbd_printer_cfg.device_id_len;
             break;
         case PRINTER_REQUEST_GET_PORT_SATTUS:

--- a/class/printer/usbh_printer.c
+++ b/class/printer/usbh_printer.c
@@ -62,7 +62,7 @@ static int usbh_printer_connect(struct usbh_hubport *hport, uint8_t intf)
         return -ENOMEM;
     }
 
-    memset(printer_class, 0, sizeof(struct usbh_printer));
+    usb_memset(printer_class, 0, sizeof(struct usbh_printer));
 
     printer_class->hport = hport;
     printer_class->intf = intf;
@@ -113,7 +113,7 @@ static int usbh_printer_disconnect(struct usbh_hubport *hport, uint8_t intf)
         if (hport->config.intf[intf].devname[0] != '\0')
             USB_LOG_INFO("Unregister Printer Class:%s\r\n", hport->config.intf[intf].devname);
 
-        memset(hport->config.intf[intf].devname, 0, CONFIG_USBHOST_DEV_NAMELEN);
+        usb_memset(hport->config.intf[intf].devname, 0, CONFIG_USBHOST_DEV_NAMELEN);
         hport->config.intf[intf].priv = NULL;
     }
 

--- a/class/template/usbh_xxx.c
+++ b/class/template/usbh_xxx.c
@@ -15,7 +15,7 @@ static int usbh_xxx_connect(struct usbh_hubport *hport, uint8_t intf)
         return -ENOMEM;
     }
 
-    memset(xxx_class, 0, sizeof(struct usbh_xxx));
+    usb_memset(xxx_class, 0, sizeof(struct usbh_xxx));
 
     xxx_class->hport = hport;
     xxx_class->intf = intf;
@@ -61,7 +61,7 @@ static int usbh_xxx_disconnect(struct usbh_hubport *hport, uint8_t intf)
         usb_free(xxx_class);
 
         USB_LOG_INFO("Unregister xxx Class:%s\r\n", hport->config.intf[intf].devname);
-        memset(hport->config.intf[intf].devname, 0, CONFIG_USBHOST_DEV_NAMELEN);
+        usb_memset(hport->config.intf[intf].devname, 0, CONFIG_USBHOST_DEV_NAMELEN);
 
         hport->config.intf[intf].priv = NULL;
     }

--- a/class/vendor/axusbnet.c
+++ b/class/vendor/axusbnet.c
@@ -406,7 +406,7 @@ static int access_eeprom_mac(struct usbnet *dev, u8 *buf, u8 offset, bool wflag)
             USB_LOG_ERR("Failed to read MAC address from EEPROM: %d\n", ret);
             return ret;
         }
-        // memcpy(dev->net->dev_addr, buf, ETH_ALEN);
+        // usb_memcpy(dev->net->dev_addr, buf, ETH_ALEN);
     } else {
         ax8817x_write_cmd(dev, AX_CMD_WRITE_EEPROM_DIS,
                           0, 0, 0, NULL);
@@ -528,7 +528,7 @@ static int ax8817x_get_mac(struct usbnet *dev, u8 *buf)
     //         }
     // }
 
-    // memcpy(dev->net->perm_addr, dev->net->dev_addr, ETH_ALEN);
+    // usb_memcpy(dev->net->perm_addr, dev->net->dev_addr, ETH_ALEN);
 
     // /* Set the MAC address */
     // ax8817x_write_cmd(dev, AX88772_CMD_WRITE_NODE_ID, 0, 0,
@@ -583,7 +583,7 @@ static rt_err_t rt_rndis_eth_control(rt_device_t dev, int cmd, void *args)
         if(args)
         {
             USB_LOG_INFO("%s L%d NIOCTL_GADDR\r\n", __FUNCTION__, __LINE__);
-            rt_memcpy(args, rndis_eth_dev->dev_addr, MAX_ADDR_LEN);
+            rt_usb_memcpy(args, rndis_eth_dev->dev_addr, MAX_ADDR_LEN);
         }
         else
         {
@@ -758,7 +758,7 @@ static void rt_thread_axusbnet_entry(void *parameter)
 		return;
 	}
     dump_hex(buf, ETH_ALEN);
-    memcpy(dev->dev_addr, buf, ETH_ALEN);
+    usb_memcpy(dev->dev_addr, buf, ETH_ALEN);
 
     uint16_t chipcode = 0xFFFF;
     {
@@ -880,7 +880,7 @@ static void rt_thread_axusbnet_entry(void *parameter)
 		goto err_out;
 	}
 
-	memset(buf, 0, 4);
+	usb_memset(buf, 0, 4);
 	ret = ax8817x_read_cmd(dev, AX_CMD_READ_IPG012, 0, 0, 3, buf);
 	*((u8 *)buf + 3) = 0x00;
 	if (ret < 0) {
@@ -1053,8 +1053,8 @@ static void rt_thread_axusbnet_entry(void *parameter)
                     send_buf[1] = sizeof(packet_bytes) >> 8;
                     send_buf[2] = ~send_buf[0];
                     send_buf[3] = ~send_buf[1];
-                    memcpy(send_buf+4, packet_bytes, sizeof(packet_bytes));
-                    memcpy(send_buf+4+6, dev->dev_addr, 6);// update src mac.
+                    usb_memcpy(send_buf+4, packet_bytes, sizeof(packet_bytes));
+                    usb_memcpy(send_buf+4+6, dev->dev_addr, 6);// update src mac.
 
                     ret = usbh_ep_bulk_transfer(class->bulkout, send_buf, 4 + sizeof(packet_bytes), 500);
                     USB_LOG_INFO("bulkout, ret=%d\r\n", ret);
@@ -1132,7 +1132,7 @@ static int usbh_axusbnet_connect(struct usbh_hubport *hport, uint8_t intf)
         USB_LOG_ERR("Fail to alloc class\r\n");
         return -ENOMEM;
     }
-    memset(class, 0, sizeof(struct usbh_axusbnet));
+    usb_memset(class, 0, sizeof(struct usbh_axusbnet));
     class->hport = hport;
 
     class->intf = intf;

--- a/class/vendor/usbh_air724.c
+++ b/class/vendor/usbh_air724.c
@@ -20,7 +20,7 @@ static inline int usbh_air724_bulk_out_transfer(struct usbh_cdc_custom_air724 *c
 {
     int ret;
     struct usbh_urb *urb = &cdc_custom_class->bulkout_urb;
-    memset(urb, 0, sizeof(struct usbh_urb));
+    usb_memset(urb, 0, sizeof(struct usbh_urb));
 
     usbh_bulk_urb_fill(urb, cdc_custom_class->bulkout, buffer, buflen, timeout, NULL, NULL);
     ret = usbh_submit_urb(urb);
@@ -46,7 +46,7 @@ int usbh_air724_connect(struct usbh_hubport *hport, uint8_t intf)
         return -ENOMEM;
     }
 
-    memset(cdc_custom_class, 0, sizeof(struct usbh_cdc_custom_air724));
+    usb_memset(cdc_custom_class, 0, sizeof(struct usbh_cdc_custom_air724));
     cdc_custom_class->hport = hport;
 
     strncpy(hport->config.intf[intf].devname, DEV_FORMAT, CONFIG_USBHOST_DEV_NAMELEN);

--- a/class/video/usbd_video.c
+++ b/class/video/usbd_video.c
@@ -93,22 +93,22 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                                 switch (setup->bRequest) {
                                     case VIDEO_REQUEST_GET_CUR: {
                                         uint32_t dwExposureTimeAbsolute = 2500;
-                                        memcpy(*data, (uint8_t *)&dwExposureTimeAbsolute, 4);
+                                        usb_memcpy(*data, (uint8_t *)&dwExposureTimeAbsolute, 4);
                                         *len = 4;
                                     } break;
                                     case VIDEO_REQUEST_GET_MIN: {
                                         uint32_t dwExposureTimeAbsolute = 5; //0.0005sec
-                                        memcpy(*data, (uint8_t *)&dwExposureTimeAbsolute, 4);
+                                        usb_memcpy(*data, (uint8_t *)&dwExposureTimeAbsolute, 4);
                                         *len = 4;
                                     } break;
                                     case VIDEO_REQUEST_GET_MAX: {
                                         uint32_t dwExposureTimeAbsolute = 2500; //0.2500sec
-                                        memcpy(*data, (uint8_t *)&dwExposureTimeAbsolute, 4);
+                                        usb_memcpy(*data, (uint8_t *)&dwExposureTimeAbsolute, 4);
                                         *len = 4;
                                     } break;
                                     case VIDEO_REQUEST_GET_RES: {
                                         uint32_t dwExposureTimeAbsolute = 5; //0.0005sec
-                                        memcpy(*data, (uint8_t *)&dwExposureTimeAbsolute, 4);
+                                        usb_memcpy(*data, (uint8_t *)&dwExposureTimeAbsolute, 4);
                                         *len = 4;
                                     } break;
                                     case VIDEO_REQUEST_GET_INFO:
@@ -117,7 +117,7 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                                         break;
                                     case VIDEO_REQUEST_GET_DEF: {
                                         uint32_t dwExposureTimeAbsolute = 2500; //0.2500sec
-                                        memcpy(*data, (uint8_t *)&dwExposureTimeAbsolute, 4);
+                                        usb_memcpy(*data, (uint8_t *)&dwExposureTimeAbsolute, 4);
                                         *len = 4;
                                     } break;
                                     default:
@@ -129,22 +129,22 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                                 switch (setup->bRequest) {
                                     case VIDEO_REQUEST_GET_CUR: {
                                         uint16_t wFocusAbsolute = 0x0080;
-                                        memcpy(*data, (uint8_t *)&wFocusAbsolute, 2);
+                                        usb_memcpy(*data, (uint8_t *)&wFocusAbsolute, 2);
                                         *len = 2;
                                     } break;
                                     case VIDEO_REQUEST_GET_MIN: {
                                         uint16_t wFocusAbsolute = 0;
-                                        memcpy(*data, (uint8_t *)&wFocusAbsolute, 2);
+                                        usb_memcpy(*data, (uint8_t *)&wFocusAbsolute, 2);
                                         *len = 2;
                                     } break;
                                     case VIDEO_REQUEST_GET_MAX: {
                                         uint16_t wFocusAbsolute = 0x00ff;
-                                        memcpy(*data, (uint8_t *)&wFocusAbsolute, 2);
+                                        usb_memcpy(*data, (uint8_t *)&wFocusAbsolute, 2);
                                         *len = 2;
                                     } break;
                                     case VIDEO_REQUEST_GET_RES: {
                                         uint16_t wFocusAbsolute = 0x0001;
-                                        memcpy(*data, (uint8_t *)&wFocusAbsolute, 2);
+                                        usb_memcpy(*data, (uint8_t *)&wFocusAbsolute, 2);
                                         *len = 2;
                                     } break;
                                     case VIDEO_REQUEST_GET_INFO:
@@ -153,7 +153,7 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                                         break;
                                     case VIDEO_REQUEST_GET_DEF: {
                                         uint16_t wFocusAbsolute = 0x0080;
-                                        memcpy(*data, (uint8_t *)&wFocusAbsolute, 2);
+                                        usb_memcpy(*data, (uint8_t *)&wFocusAbsolute, 2);
                                         *len = 2;
                                     } break;
                                     default:
@@ -165,22 +165,22 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                                 switch (setup->bRequest) {
                                     case VIDEO_REQUEST_GET_CUR: {
                                         uint16_t wObjectiveFocalLength = 0x0064;
-                                        memcpy(*data, (uint8_t *)&wObjectiveFocalLength, 2);
+                                        usb_memcpy(*data, (uint8_t *)&wObjectiveFocalLength, 2);
                                         *len = 2;
                                     } break;
                                     case VIDEO_REQUEST_GET_MIN: {
                                         uint16_t wObjectiveFocalLength = 0x0064;
-                                        memcpy(*data, (uint8_t *)&wObjectiveFocalLength, 2);
+                                        usb_memcpy(*data, (uint8_t *)&wObjectiveFocalLength, 2);
                                         *len = 2;
                                     } break;
                                     case VIDEO_REQUEST_GET_MAX: {
                                         uint16_t wObjectiveFocalLength = 0x00c8;
-                                        memcpy(*data, (uint8_t *)&wObjectiveFocalLength, 2);
+                                        usb_memcpy(*data, (uint8_t *)&wObjectiveFocalLength, 2);
                                         *len = 2;
                                     } break;
                                     case VIDEO_REQUEST_GET_RES: {
                                         uint16_t wObjectiveFocalLength = 0x0001;
-                                        memcpy(*data, (uint8_t *)&wObjectiveFocalLength, 2);
+                                        usb_memcpy(*data, (uint8_t *)&wObjectiveFocalLength, 2);
                                         *len = 2;
                                     } break;
                                     case VIDEO_REQUEST_GET_INFO:
@@ -189,7 +189,7 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                                         break;
                                     case VIDEO_REQUEST_GET_DEF: {
                                         uint16_t wObjectiveFocalLength = 0x0064;
-                                        memcpy(*data, (uint8_t *)&wObjectiveFocalLength, 2);
+                                        usb_memcpy(*data, (uint8_t *)&wObjectiveFocalLength, 2);
                                         *len = 2;
                                     } break;
                                     default:
@@ -201,22 +201,22 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                                 switch (setup->bRequest) {
                                     case VIDEO_REQUEST_GET_CUR: {
                                         uint16_t wRollAbsolute = 0x0000;
-                                        memcpy(*data, (uint8_t *)&wRollAbsolute, 2);
+                                        usb_memcpy(*data, (uint8_t *)&wRollAbsolute, 2);
                                         *len = 2;
                                     } break;
                                     case VIDEO_REQUEST_GET_MIN: {
                                         uint16_t wRollAbsolute = 0x0000;
-                                        memcpy(*data, (uint8_t *)&wRollAbsolute, 2);
+                                        usb_memcpy(*data, (uint8_t *)&wRollAbsolute, 2);
                                         *len = 2;
                                     } break;
                                     case VIDEO_REQUEST_GET_MAX: {
                                         uint16_t wRollAbsolute = 0x00ff;
-                                        memcpy(*data, (uint8_t *)&wRollAbsolute, 2);
+                                        usb_memcpy(*data, (uint8_t *)&wRollAbsolute, 2);
                                         *len = 2;
                                     } break;
                                     case VIDEO_REQUEST_GET_RES: {
                                         uint16_t wRollAbsolute = 0x0001;
-                                        memcpy(*data, (uint8_t *)&wRollAbsolute, 2);
+                                        usb_memcpy(*data, (uint8_t *)&wRollAbsolute, 2);
                                         *len = 2;
                                     } break;
                                     case VIDEO_REQUEST_GET_INFO:
@@ -225,7 +225,7 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                                         break;
                                     case VIDEO_REQUEST_GET_DEF: {
                                         uint16_t wRollAbsolute = 0x0000;
-                                        memcpy(*data, (uint8_t *)&wRollAbsolute, 2);
+                                        usb_memcpy(*data, (uint8_t *)&wRollAbsolute, 2);
                                         *len = 2;
                                     } break;
                                     default:
@@ -237,7 +237,7 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                                 switch (setup->bRequest) {
                                     case VIDEO_REQUEST_GET_CUR: {
                                         uint16_t wFocusAuto = 0x0000;
-                                        memcpy(*data, (uint8_t *)&wFocusAuto, 2);
+                                        usb_memcpy(*data, (uint8_t *)&wFocusAuto, 2);
                                         *len = 2;
                                     } break;
                                     default:
@@ -264,22 +264,22 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                             switch (setup->bRequest) {
                                 case VIDEO_REQUEST_GET_CUR: {
                                     uint16_t wBacklightCompensation = 0x0004;
-                                    memcpy(*data, (uint8_t *)&wBacklightCompensation, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wBacklightCompensation, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_MIN: {
                                     uint16_t wBacklightCompensation = 0;
-                                    memcpy(*data, (uint8_t *)&wBacklightCompensation, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wBacklightCompensation, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_MAX: {
                                     uint16_t wBacklightCompensation = 8;
-                                    memcpy(*data, (uint8_t *)&wBacklightCompensation, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wBacklightCompensation, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_RES: {
                                     uint16_t wBacklightCompensation = 1;
-                                    memcpy(*data, (uint8_t *)&wBacklightCompensation, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wBacklightCompensation, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_INFO:
@@ -288,7 +288,7 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                                     break;
                                 case VIDEO_REQUEST_GET_DEF: {
                                     uint16_t wBacklightCompensation = 4;
-                                    memcpy(*data, (uint8_t *)&wBacklightCompensation, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wBacklightCompensation, 2);
                                     *len = 2;
                                 } break;
                                 default:
@@ -304,22 +304,22 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                                 } break;
                                 case VIDEO_REQUEST_GET_CUR: {
                                     uint16_t wBrightness = 0x0080;
-                                    memcpy(*data, (uint8_t *)&wBrightness, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wBrightness, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_MIN: {
                                     uint16_t wBrightness = 0x0001;
-                                    memcpy(*data, (uint8_t *)&wBrightness, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wBrightness, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_MAX: {
                                     uint16_t wBrightness = 0x00ff;
-                                    memcpy(*data, (uint8_t *)&wBrightness, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wBrightness, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_RES: {
                                     uint16_t wBrightness = 0x0001;
-                                    memcpy(*data, (uint8_t *)&wBrightness, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wBrightness, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_INFO:
@@ -328,7 +328,7 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                                     break;
                                 case VIDEO_REQUEST_GET_DEF: {
                                     uint16_t wBrightness = 0x0080;
-                                    memcpy(*data, (uint8_t *)&wBrightness, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wBrightness, 2);
                                     *len = 2;
                                 } break;
                                 default:
@@ -340,22 +340,22 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                             switch (setup->bRequest) {
                                 case VIDEO_REQUEST_GET_CUR: {
                                     uint16_t wContrast = 0x0080;
-                                    memcpy(*data, (uint8_t *)&wContrast, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wContrast, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_MIN: {
                                     uint16_t wContrast = 0x0001;
-                                    memcpy(*data, (uint8_t *)&wContrast, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wContrast, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_MAX: {
                                     uint16_t wContrast = 0x00ff;
-                                    memcpy(*data, (uint8_t *)&wContrast, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wContrast, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_RES: {
                                     uint16_t wContrast = 0x0001;
-                                    memcpy(*data, (uint8_t *)&wContrast, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wContrast, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_INFO:
@@ -364,7 +364,7 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                                     break;
                                 case VIDEO_REQUEST_GET_DEF: {
                                     uint16_t wContrast = 0x0080;
-                                    memcpy(*data, (uint8_t *)&wContrast, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wContrast, 2);
                                     *len = 2;
                                 } break;
                                 default:
@@ -376,22 +376,22 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                             switch (setup->bRequest) {
                                 case VIDEO_REQUEST_GET_CUR: {
                                     uint16_t wHue = 0x0080;
-                                    memcpy(*data, (uint8_t *)&wHue, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wHue, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_MIN: {
                                     uint16_t wHue = 0x0001;
-                                    memcpy(*data, (uint8_t *)&wHue, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wHue, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_MAX: {
                                     uint16_t wHue = 0x00ff;
-                                    memcpy(*data, (uint8_t *)&wHue, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wHue, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_RES: {
                                     uint16_t wHue = 0x0001;
-                                    memcpy(*data, (uint8_t *)&wHue, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wHue, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_INFO:
@@ -400,7 +400,7 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                                     break;
                                 case VIDEO_REQUEST_GET_DEF: {
                                     uint16_t wHue = 0x0080;
-                                    memcpy(*data, (uint8_t *)&wHue, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wHue, 2);
                                     *len = 2;
                                 } break;
                                 default:
@@ -412,17 +412,17 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                             switch (setup->bRequest) {
                                 case VIDEO_REQUEST_GET_MIN: {
                                     uint16_t wSaturation = 0x0001;
-                                    memcpy(*data, (uint8_t *)&wSaturation, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wSaturation, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_MAX: {
                                     uint16_t wSaturation = 0x00ff;
-                                    memcpy(*data, (uint8_t *)&wSaturation, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wSaturation, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_RES: {
                                     uint16_t wSaturation = 0x0001;
-                                    memcpy(*data, (uint8_t *)&wSaturation, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wSaturation, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_INFO:
@@ -431,7 +431,7 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                                     break;
                                 case VIDEO_REQUEST_GET_DEF: {
                                     uint16_t wSaturation = 0x0080;
-                                    memcpy(*data, (uint8_t *)&wSaturation, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wSaturation, 2);
                                     *len = 2;
                                 } break;
                                 default:
@@ -443,17 +443,17 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                             switch (setup->bRequest) {
                                 case VIDEO_REQUEST_GET_MIN: {
                                     uint16_t wSharpness = 0x0001;
-                                    memcpy(*data, (uint8_t *)&wSharpness, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wSharpness, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_MAX: {
                                     uint16_t wSharpness = 0x00ff;
-                                    memcpy(*data, (uint8_t *)&wSharpness, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wSharpness, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_RES: {
                                     uint16_t wSharpness = 0x0001;
-                                    memcpy(*data, (uint8_t *)&wSharpness, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wSharpness, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_INFO:
@@ -462,7 +462,7 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                                     break;
                                 case VIDEO_REQUEST_GET_DEF: {
                                     uint16_t wSharpness = 0x0080;
-                                    memcpy(*data, (uint8_t *)&wSharpness, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wSharpness, 2);
                                     *len = 2;
                                 } break;
                                 default:
@@ -474,17 +474,17 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                             switch (setup->bRequest) {
                                 case VIDEO_REQUEST_GET_MIN: {
                                     uint16_t wGain = 0;
-                                    memcpy(*data, (uint8_t *)&wGain, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wGain, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_MAX: {
                                     uint16_t wGain = 255;
-                                    memcpy(*data, (uint8_t *)&wGain, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wGain, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_RES: {
                                     uint16_t wGain = 1;
-                                    memcpy(*data, (uint8_t *)&wGain, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wGain, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_INFO:
@@ -493,7 +493,7 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                                     break;
                                 case VIDEO_REQUEST_GET_DEF: {
                                     uint16_t wGain = 255;
-                                    memcpy(*data, (uint8_t *)&wGain, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wGain, 2);
                                     *len = 2;
                                 } break;
                                 default:
@@ -505,22 +505,22 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                             switch (setup->bRequest) {
                                 case VIDEO_REQUEST_GET_CUR: {
                                     uint16_t wWhiteBalance_Temprature = 417;
-                                    memcpy(*data, (uint8_t *)&wWhiteBalance_Temprature, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wWhiteBalance_Temprature, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_MIN: {
                                     uint16_t wWhiteBalance_Temprature = 300;
-                                    memcpy(*data, (uint8_t *)&wWhiteBalance_Temprature, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wWhiteBalance_Temprature, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_MAX: {
                                     uint16_t wWhiteBalance_Temprature = 600;
-                                    memcpy(*data, (uint8_t *)&wWhiteBalance_Temprature, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wWhiteBalance_Temprature, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_RES: {
                                     uint16_t wWhiteBalance_Temprature = 1;
-                                    memcpy(*data, (uint8_t *)&wWhiteBalance_Temprature, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wWhiteBalance_Temprature, 2);
                                     *len = 2;
                                 } break;
                                 case VIDEO_REQUEST_GET_INFO:
@@ -529,7 +529,7 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                                     break;
                                 case VIDEO_REQUEST_GET_DEF: {
                                     uint16_t wWhiteBalance_Temprature = 417;
-                                    memcpy(*data, (uint8_t *)&wWhiteBalance_Temprature, 2);
+                                    usb_memcpy(*data, (uint8_t *)&wWhiteBalance_Temprature, 2);
                                     *len = 2;
                                 } break;
                                 default:
@@ -541,7 +541,7 @@ static int usbd_video_control_unit_terminal_request_handler(struct usb_setup_pac
                             switch (setup->bRequest) {
                                 case VIDEO_REQUEST_GET_CUR: {
                                     uint16_t wWhiteBalance_Temprature_Auto = 1;
-                                    memcpy(*data, (uint8_t *)&wWhiteBalance_Temprature_Auto, 1);
+                                    usb_memcpy(*data, (uint8_t *)&wWhiteBalance_Temprature_Auto, 1);
                                     *len = 1;
                                 } break;
                                 default:
@@ -576,10 +576,10 @@ static int usbd_video_stream_request_handler(struct usb_setup_packet *setup, uin
         case VIDEO_VS_PROBE_CONTROL:
             switch (setup->bRequest) {
                 case VIDEO_REQUEST_SET_CUR:
-                    //memcpy((uint8_t *)&usbd_video_cfg.probe, *data, setup->wLength);
+                    //usb_memcpy((uint8_t *)&usbd_video_cfg.probe, *data, setup->wLength);
                     break;
                 case VIDEO_REQUEST_GET_CUR:
-                    memcpy(*data, (uint8_t *)&usbd_video_cfg.probe, setup->wLength);
+                    usb_memcpy(*data, (uint8_t *)&usbd_video_cfg.probe, setup->wLength);
                     *len = sizeof(struct video_probe_and_commit_controls);
                     break;
 
@@ -587,7 +587,7 @@ static int usbd_video_stream_request_handler(struct usb_setup_packet *setup, uin
                 case VIDEO_REQUEST_GET_MAX:
                 case VIDEO_REQUEST_GET_RES:
                 case VIDEO_REQUEST_GET_DEF:
-                    memcpy(*data, (uint8_t *)&usbd_video_cfg.probe, setup->wLength);
+                    usb_memcpy(*data, (uint8_t *)&usbd_video_cfg.probe, setup->wLength);
                     *len = sizeof(struct video_probe_and_commit_controls);
                     break;
                 case VIDEO_REQUEST_GET_LEN:
@@ -608,17 +608,17 @@ static int usbd_video_stream_request_handler(struct usb_setup_packet *setup, uin
         case VIDEO_VS_COMMIT_CONTROL:
             switch (setup->bRequest) {
                 case VIDEO_REQUEST_SET_CUR:
-                    //memcpy((uint8_t *)&usbd_video_cfg.commit, *data, setup->wLength);
+                    //usb_memcpy((uint8_t *)&usbd_video_cfg.commit, *data, setup->wLength);
                     break;
                 case VIDEO_REQUEST_GET_CUR:
-                    memcpy(*data, (uint8_t *)&usbd_video_cfg.commit, setup->wLength);
+                    usb_memcpy(*data, (uint8_t *)&usbd_video_cfg.commit, setup->wLength);
                     *len = sizeof(struct video_probe_and_commit_controls);
                     break;
                 case VIDEO_REQUEST_GET_MIN:
                 case VIDEO_REQUEST_GET_MAX:
                 case VIDEO_REQUEST_GET_RES:
                 case VIDEO_REQUEST_GET_DEF:
-                    memcpy(*data, (uint8_t *)&usbd_video_cfg.commit, setup->wLength);
+                    usb_memcpy(*data, (uint8_t *)&usbd_video_cfg.commit, setup->wLength);
                     *len = sizeof(struct video_probe_and_commit_controls);
                     break;
 
@@ -770,10 +770,10 @@ uint32_t usbd_video_mjpeg_payload_fill(uint8_t *input, uint32_t input_len, uint8
         output[usbd_video_cfg.probe.dwMaxPayloadTransferSize * i] = uvc_header[0];
         output[usbd_video_cfg.probe.dwMaxPayloadTransferSize * i + 1] = uvc_header[1];
         if (i == (packets - 1)) {
-            memcpy(&output[2 + usbd_video_cfg.probe.dwMaxPayloadTransferSize * i], &input[picture_pos], last_packet_size - 2);
+            usb_memcpy(&output[2 + usbd_video_cfg.probe.dwMaxPayloadTransferSize * i], &input[picture_pos], last_packet_size - 2);
             output[usbd_video_cfg.probe.dwMaxPayloadTransferSize * i + 1] |= (1 << 1);
         } else {
-            memcpy(&output[2 + usbd_video_cfg.probe.dwMaxPayloadTransferSize * i], &input[picture_pos], usbd_video_cfg.probe.dwMaxPayloadTransferSize - 2);
+            usb_memcpy(&output[2 + usbd_video_cfg.probe.dwMaxPayloadTransferSize * i], &input[picture_pos], usbd_video_cfg.probe.dwMaxPayloadTransferSize - 2);
             picture_pos += usbd_video_cfg.probe.dwMaxPayloadTransferSize - 2;
         }
     }

--- a/class/video/usbh_video.c
+++ b/class/video/usbh_video.c
@@ -67,7 +67,7 @@ int usbh_video_get_cur(struct usbh_video *video_class, uint8_t intf, uint8_t ent
     if (ret < 0) {
         return ret;
     }
-    memcpy(buf, g_video_buf, len);
+    usb_memcpy(buf, g_video_buf, len);
     return ret;
 }
 
@@ -82,7 +82,7 @@ int usbh_video_set_cur(struct usbh_video *video_class, uint8_t intf, uint8_t ent
     setup->wIndex = (entity_id << 8) | intf;
     setup->wLength = len;
 
-    memcpy(g_video_buf, buf, len);
+    usb_memcpy(g_video_buf, buf, len);
 
     ret = usbh_control_transfer(video_class->hport->ep0, setup, g_video_buf);
     usb_osal_msleep(5);
@@ -104,7 +104,7 @@ int usbh_videostreaming_set_cur_probe(struct usbh_video *video_class, uint8_t fo
 
 int usbh_videostreaming_set_cur_commit(struct usbh_video *video_class, uint8_t formatindex, uint8_t frameindex)
 {
-    memcpy(&video_class->commit, &video_class->probe, sizeof(struct video_probe_and_commit_controls));
+    usb_memcpy(&video_class->commit, &video_class->probe, sizeof(struct video_probe_and_commit_controls));
     video_class->commit.bFormatIndex = formatindex;
     video_class->commit.bFrameIndex = frameindex;
     return usbh_video_set_cur(video_class, video_class->data_intf, 0x00, VIDEO_VS_COMMIT_CONTROL, (uint8_t *)&video_class->commit, 26);
@@ -298,7 +298,7 @@ static int usbh_video_ctrl_connect(struct usbh_hubport *hport, uint8_t intf)
         return -ENOMEM;
     }
 
-    memset(video_class, 0, sizeof(struct usbh_video));
+    usb_memset(video_class, 0, sizeof(struct usbh_video));
     usbh_video_devno_alloc(video_class);
     video_class->hport = hport;
     video_class->ctrl_intf = intf;
@@ -412,7 +412,7 @@ static int usbh_video_ctrl_disconnect(struct usbh_hubport *hport, uint8_t intf)
         }
 
         usbh_video_stop(video_class);
-        memset(video_class, 0, sizeof(struct usbh_video));
+        usb_memset(video_class, 0, sizeof(struct usbh_video));
         usb_free(video_class);
 
         if (hport->config.intf[intf].devname[0] != '\0')

--- a/class/wireless/usbd_rndis.c
+++ b/class/wireless/usbd_rndis.c
@@ -14,7 +14,7 @@
 /* Describe EndPoints configuration */
 static struct usbd_endpoint rndis_ep_data[3];
 
-#define RNDIS_INQUIRY_PUT(src, len)   (memcpy(infomation_buffer, src, len))
+#define RNDIS_INQUIRY_PUT(src, len)   (usb_memcpy(infomation_buffer, src, len))
 #define RNDIS_INQUIRY_PUT_LE32(value) (*(uint32_t *)infomation_buffer = (value))
 
 #ifdef CONFIG_USB_HS
@@ -102,7 +102,7 @@ static int rndis_encapsulated_cmd_handler(uint8_t *data, uint32_t len);
 
 static void rndis_notify_rsp(void)
 {
-    memset(NOTIFY_RESPONSE_AVAILABLE, 0, 8);
+    usb_memset(NOTIFY_RESPONSE_AVAILABLE, 0, 8);
     NOTIFY_RESPONSE_AVAILABLE[0] = 0x01;
     usbd_ep_start_write(rndis_ep_data[RNDIS_INT_EP_IDX].ep_addr, NOTIFY_RESPONSE_AVAILABLE, 8);
 }
@@ -490,7 +490,7 @@ struct pbuf *usbd_rndis_eth_rx(void)
     if (p == NULL) {
         return NULL;
     }
-    memcpy(p->payload, (uint8_t *)g_rndis_rx_data_buffer, g_rndis_rx_data_length);
+    usb_memcpy(p->payload, (uint8_t *)g_rndis_rx_data_buffer, g_rndis_rx_data_length);
     p->len = g_rndis_rx_data_length;
 
     USB_LOG_DBG("rxlen:%d\r\n", g_rndis_rx_data_length);
@@ -520,13 +520,13 @@ int usbd_rndis_eth_tx(struct pbuf *p)
 
     buffer = (uint8_t *)(g_rndis_tx_buffer + sizeof(rndis_data_packet_t));
     for (q = p; q != NULL; q = q->next) {
-        memcpy(buffer, q->payload, q->len);
+        usb_memcpy(buffer, q->payload, q->len);
         buffer += q->len;
     }
 
     hdr = (rndis_data_packet_t *)g_rndis_tx_buffer;
 
-    memset(hdr, 0, sizeof(rndis_data_packet_t));
+    usb_memset(hdr, 0, sizeof(rndis_data_packet_t));
     hdr->MessageType = REMOTE_NDIS_PACKET_MSG;
     hdr->MessageLength = sizeof(rndis_data_packet_t) + p->tot_len;
     hdr->DataOffset = sizeof(rndis_data_packet_t) - sizeof(rndis_generic_msg_t);
@@ -543,7 +543,7 @@ struct usbd_interface *usbd_rndis_init_intf(struct usbd_interface *intf,
                                             const uint8_t in_ep,
                                             const uint8_t int_ep, uint8_t mac[6])
 {
-    memcpy(usbd_rndis_cfg.mac, mac, 6);
+    usb_memcpy(usbd_rndis_cfg.mac, mac, 6);
 
     rndis_ep_data[RNDIS_OUT_EP_IDX].ep_addr = out_ep;
     rndis_ep_data[RNDIS_OUT_EP_IDX].ep_cb = rndis_bulk_out;

--- a/class/wireless/usbh_rndis.c
+++ b/class/wireless/usbh_rndis.c
@@ -103,7 +103,7 @@ int usbh_rndis_query_msg_transfer(struct usbh_rndis *rndis_class, uint32_t oid, 
         return ret;
     }
 
-    memcpy(info, ((uint8_t *)resp + sizeof(rndis_query_cmplt_t)), resp->InformationBufferLength);
+    usb_memcpy(info, ((uint8_t *)resp + sizeof(rndis_query_cmplt_t)), resp->InformationBufferLength);
     *info_len = resp->InformationBufferLength;
 
     return ret;
@@ -126,7 +126,7 @@ static int usbh_rndis_set_msg_transfer(struct usbh_rndis *rndis_class, uint32_t 
     cmd->InformationBufferOffset = 20;
     cmd->DeviceVcHandle = 0;
 
-    memcpy(((uint8_t *)cmd + sizeof(rndis_set_msg_t)), info, info_len);
+    usb_memcpy(((uint8_t *)cmd + sizeof(rndis_set_msg_t)), info, info_len);
     setup->bmRequestType = USB_REQUEST_DIR_OUT | USB_REQUEST_CLASS | USB_REQUEST_RECIPIENT_INTERFACE;
     setup->bRequest = CDC_REQUEST_SEND_ENCAPSULATED_COMMAND;
     setup->wValue = 0;
@@ -162,7 +162,7 @@ int usbh_rndis_bulk_out_transfer(struct usbh_rndis *rndis_class, uint8_t *buffer
 {
     int ret;
     struct usbh_urb *urb = &rndis_class->bulkout_urb;
-    memset(urb, 0, sizeof(struct usbh_urb));
+    usb_memset(urb, 0, sizeof(struct usbh_urb));
 
     usbh_bulk_urb_fill(urb, rndis_class->bulkout, buffer, buflen, timeout, NULL, NULL);
     ret = usbh_submit_urb(urb);
@@ -176,7 +176,7 @@ int usbh_rndis_bulk_in_transfer(struct usbh_rndis *rndis_class, uint8_t *buffer,
 {
     int ret;
     struct usbh_urb *urb = &rndis_class->bulkin_urb;
-    memset(urb, 0, sizeof(struct usbh_urb));
+    usb_memset(urb, 0, sizeof(struct usbh_urb));
 
     usbh_bulk_urb_fill(urb, rndis_class->bulkin, buffer, buflen, timeout, NULL, NULL);
     ret = usbh_submit_urb(urb);
@@ -248,7 +248,7 @@ static int usbh_rndis_connect(struct usbh_hubport *hport, uint8_t intf)
         return -ENOMEM;
     }
 
-    memset(rndis_class, 0, sizeof(struct usbh_rndis));
+    usb_memset(rndis_class, 0, sizeof(struct usbh_rndis));
 
     rndis_class->hport = hport;
     rndis_class->ctrl_intf = intf;
@@ -314,7 +314,7 @@ static int usbh_rndis_connect(struct usbh_hubport *hport, uint8_t intf)
                     goto query_errorout;
                 }
 
-                memcpy(&rndis_class->link_speed, data, 4);
+                usb_memcpy(&rndis_class->link_speed, data, 4);
                 break;
             case OID_GEN_MEDIA_CONNECT_STATUS:
                 ret = usbh_rndis_query_msg_transfer(rndis_class, OID_GEN_MEDIA_CONNECT_STATUS, 4, data, &data_len);
@@ -396,7 +396,7 @@ static int usbh_rndis_disconnect(struct usbh_hubport *hport, uint8_t intf)
         }
 
         usbh_rndis_stop(rndis_class);
-        memset(rndis_class, 0, sizeof(struct usbh_rndis));
+        usb_memset(rndis_class, 0, sizeof(struct usbh_rndis));
         usb_free(rndis_class);
 
         if (hport->config.intf[intf].devname[0] != '\0')

--- a/core/usbd_core.c
+++ b/core/usbd_core.c
@@ -346,7 +346,7 @@ static bool usbd_get_descriptor(uint16_t type_index, uint8_t **data, uint32_t *l
             /* normally length is at offset 0 */
             *len = p[DESC_bLength];
         }
-        memcpy(*data, p, *len);
+        usb_memcpy(*data, p, *len);
     } else {
         /* nothing found */
         USB_LOG_ERR("descriptor <type:%x,index:%x> not found!\r\n", type, index);
@@ -611,7 +611,7 @@ static bool usbd_std_interface_req_handler(struct usb_setup_packet *setup,
 
                     if (intf->intf_num == intf_num) {
                         //*data = (uint8_t *)intf->hid_report_descriptor;
-                        memcpy(*data, intf->hid_report_descriptor, intf->hid_report_descriptor_len);
+                        usb_memcpy(*data, intf->hid_report_descriptor, intf->hid_report_descriptor_len);
                         *len = intf->hid_report_descriptor_len;
                         return true;
                     }
@@ -844,14 +844,14 @@ static int usbd_vendor_request_handler(struct usb_setup_packet *setup, uint8_t *
                 case 0x04:
                     USB_LOG_INFO("get Compat ID\r\n");
                     //*data = (uint8_t *)msosv1_desc->compat_id;
-                    memcpy(*data, msosv1_desc->compat_id, msosv1_desc->compat_id_len);
+                    usb_memcpy(*data, msosv1_desc->compat_id, msosv1_desc->compat_id_len);
                     *len = msosv1_desc->compat_id_len;
 
                     return 0;
                 case 0x05:
                     USB_LOG_INFO("get Compat id properties\r\n");
                     //*data = (uint8_t *)msosv1_desc->comp_id_property;
-                    memcpy(*data, msosv1_desc->comp_id_property, msosv1_desc->comp_id_property_len);
+                    usb_memcpy(*data, msosv1_desc->comp_id_property, msosv1_desc->comp_id_property_len);
                     *len = msosv1_desc->comp_id_property_len;
 
                     return 0;
@@ -866,7 +866,7 @@ static int usbd_vendor_request_handler(struct usb_setup_packet *setup, uint8_t *
                 case WINUSB_REQUEST_GET_DESCRIPTOR_SET:
                     USB_LOG_INFO("GET MS OS 2.0 Descriptor\r\n");
                     //*data = (uint8_t *)msosv2_desc->compat_id;
-                    memcpy(*data, msosv2_desc->compat_id, msosv2_desc->compat_id_len);
+                    usb_memcpy(*data, msosv2_desc->compat_id, msosv2_desc->compat_id_len);
                     *len = msosv2_desc->compat_id_len;
                     return 0;
                 default:
@@ -997,7 +997,7 @@ void usbd_event_ep0_setup_complete_handler(uint8_t *psetup)
 {
     struct usb_setup_packet *setup = &usbd_core_cfg.setup;
 
-    memcpy(setup, psetup, 8);
+    usb_memcpy(setup, psetup, 8);
 #ifdef CONFIG_USBDEV_SETUP_LOG_PRINT
     usbd_print_setup(setup);
 #endif
@@ -1180,7 +1180,7 @@ static void usbdev_rx_thread(void *argument)
 #ifdef CONFIG_USBDEV_ADVANCE_DESC
 void usbd_desc_register(struct usb_descriptor *desc)
 {
-    memset(&usbd_core_cfg, 0, sizeof(struct usbd_core_cfg_priv));
+    usb_memset(&usbd_core_cfg, 0, sizeof(struct usbd_core_cfg_priv));
 
     usbd_core_cfg.descriptors = desc;
     usbd_core_cfg.intf_offset = 0;
@@ -1193,7 +1193,7 @@ void usbd_desc_register(struct usb_descriptor *desc)
 #else
 void usbd_desc_register(const uint8_t *desc)
 {
-    memset(&usbd_core_cfg, 0, sizeof(struct usbd_core_cfg_priv));
+    usb_memset(&usbd_core_cfg, 0, sizeof(struct usbd_core_cfg_priv));
 
     usbd_core_cfg.descriptors = desc;
     usbd_core_cfg.intf_offset = 0;

--- a/core/usbh_core.c
+++ b/core/usbh_core.c
@@ -216,7 +216,7 @@ static int parse_config_descriptor(struct usbh_hubport *hport, struct usb_config
         p += USB_SIZEOF_CONFIG_DESC;
         desc_len = USB_SIZEOF_CONFIG_DESC;
 
-        memset(hport->config.intf, 0, sizeof(struct usbh_interface) * CONFIG_USBHOST_MAX_INTERFACES);
+        usb_memset(hport->config.intf, 0, sizeof(struct usbh_interface) * CONFIG_USBHOST_MAX_INTERFACES);
 
         while (p[DESC_bLength] && (desc_len <= length)) {
             switch (p[DESC_bDescriptorType]) {
@@ -250,12 +250,12 @@ static int parse_config_descriptor(struct usbh_hubport *hport, struct usb_config
                     USB_LOG_DBG("bInterfaceProtocol: 0x%02x \r\n", intf_desc->bInterfaceProtocol);
                     USB_LOG_DBG("iInterface: 0x%02x         \r\n", intf_desc->iInterface);
 #endif
-                    memcpy(&hport->config.intf[cur_iface].altsetting[cur_alt_setting].intf_desc, intf_desc, 9);
+                    usb_memcpy(&hport->config.intf[cur_iface].altsetting[cur_alt_setting].intf_desc, intf_desc, 9);
                     hport->config.intf[cur_iface].altsetting_num = cur_alt_setting + 1;
                     break;
                 case USB_DESCRIPTOR_TYPE_ENDPOINT:
                     ep_desc = (struct usb_endpoint_descriptor *)p;
-                    memcpy(&hport->config.intf[cur_iface].altsetting[cur_alt_setting].ep[cur_ep].ep_desc, ep_desc, 7);
+                    usb_memcpy(&hport->config.intf[cur_iface].altsetting[cur_alt_setting].ep[cur_ep].ep_desc, ep_desc, 7);
                     cur_ep++;
                     break;
 
@@ -551,7 +551,7 @@ int usbh_enumerate(struct usbh_hubport *hport)
         USB_LOG_ERR("No memory to alloc for raw_config_desc\r\n");
         goto errout;
     }
-    memcpy(hport->raw_config_desc, ep0_request_buffer, wTotalLength);
+    usb_memcpy(hport->raw_config_desc, ep0_request_buffer, wTotalLength);
 #ifdef CONFIG_USBHOST_GET_STRING_DESC
     /* Get Manufacturer string */
     setup->bmRequestType = USB_REQUEST_DIR_IN | USB_REQUEST_STANDARD | USB_REQUEST_RECIPIENT_DEVICE;
@@ -681,7 +681,7 @@ void *usbh_find_class_instance(const char *devname)
 
 int usbh_initialize(void)
 {
-    memset(&g_usbh_bus, 0, sizeof(struct usbh_bus));
+    usb_memset(&g_usbh_bus, 0, sizeof(struct usbh_bus));
 
 #ifdef __ARMCC_VERSION /* ARM C Compiler */
     extern const int usbh_class_info$$Base;
@@ -711,7 +711,7 @@ int usbh_control_transfer(usbh_pipe_t pipe, struct usb_setup_packet *setup, uint
     int ret;
 
     urb = usb_malloc(sizeof(struct usbh_urb));
-    memset(urb, 0, sizeof(struct usbh_urb));
+    usb_memset(urb, 0, sizeof(struct usbh_urb));
 
     usbh_control_urb_fill(urb, pipe, setup, buffer, setup->wLength, CONFIG_USBHOST_CONTROL_TRANSFER_TIMEOUT, NULL, NULL);
 

--- a/port/ch32/usb_ch58x_dc_usbfs.c
+++ b/port/ch32/usb_ch58x_dc_usbfs.c
@@ -246,7 +246,7 @@ int usbd_ep_start_write(const uint8_t ep, const uint8_t *data, uint32_t data_len
         /*!< Not zlp */
         data_len = MIN(data_len, usb_dc_cfg.ep_in[ep_idx].mps);
         /*!< write buff */
-        memcpy(usb_dc_cfg.ep_in[ep_idx].ep_ram_addr, data, data_len);
+        usb_memcpy(usb_dc_cfg.ep_in[ep_idx].ep_ram_addr, data, data_len);
         /*!< write real_wt_nums len data */
         EPn_SET_TX_LEN(ep_idx, data_len);
         /*!< enable tx */
@@ -515,9 +515,9 @@ USBD_IRQHandler(void)
                             usb_dc_cfg.ep_in[epid].xfer_len -= usb_dc_cfg.ep_in[epid].mps;
                             usb_dc_cfg.ep_in[epid].actual_xfer_len += usb_dc_cfg.ep_in[epid].mps;
                             if (usb_dc_cfg.ep_in[epid].xfer_len > usb_dc_cfg.ep_in[epid].mps) {
-                                memcpy(usb_dc_cfg.ep_in[epid].ep_ram_addr, usb_dc_cfg.ep_in[epid].xfer_buf, usb_dc_cfg.ep_in[epid].mps);
+                                usb_memcpy(usb_dc_cfg.ep_in[epid].ep_ram_addr, usb_dc_cfg.ep_in[epid].xfer_buf, usb_dc_cfg.ep_in[epid].mps);
                             } else {
-                                memcpy(usb_dc_cfg.ep_in[epid].ep_ram_addr, usb_dc_cfg.ep_in[epid].xfer_buf, usb_dc_cfg.ep_in[epid].xfer_len);
+                                usb_memcpy(usb_dc_cfg.ep_in[epid].ep_ram_addr, usb_dc_cfg.ep_in[epid].xfer_buf, usb_dc_cfg.ep_in[epid].xfer_len);
                             }
                             if (usb_dc_cfg.ep_in[epid].eptype != USB_ENDPOINT_TYPE_ISOCHRONOUS) {
                                 EPn_SET_TX_VALID(epid);
@@ -536,7 +536,7 @@ USBD_IRQHandler(void)
                         /*!< ep0 out */
                         CH58x_USBFS_DEV->UEP0_CTRL ^= RB_UEP_R_TOG;
                         uint32_t read_count = EPn_GET_RX_LEN(0);
-                        memcpy(usb_dc_cfg.ep_out[epid].xfer_buf, usb_dc_cfg.ep_out[epid].ep_ram_addr, read_count);
+                        usb_memcpy(usb_dc_cfg.ep_out[epid].xfer_buf, usb_dc_cfg.ep_out[epid].ep_ram_addr, read_count);
 
                         usb_dc_cfg.ep_out[0].actual_xfer_len += read_count;
                         usb_dc_cfg.ep_out[0].xfer_len -= read_count;
@@ -551,7 +551,7 @@ USBD_IRQHandler(void)
                                 CH58x_USBFS_DEV->UEP4_CTRL ^= RB_UEP_R_TOG;
                             }
                             uint32_t read_count = EPn_GET_RX_LEN(epid);
-                            memcpy(usb_dc_cfg.ep_out[epid].xfer_buf, usb_dc_cfg.ep_out[epid].ep_ram_addr, read_count);
+                            usb_memcpy(usb_dc_cfg.ep_out[epid].xfer_buf, usb_dc_cfg.ep_out[epid].ep_ram_addr, read_count);
                             usb_dc_cfg.ep_out[epid].xfer_buf += read_count;
                             usb_dc_cfg.ep_out[epid].actual_xfer_len += read_count;
                             usb_dc_cfg.ep_out[epid].xfer_len -= read_count;

--- a/port/ch32/usb_dc_usbfs.c
+++ b/port/ch32/usb_dc_usbfs.c
@@ -208,7 +208,7 @@ int usbd_ep_start_write(const uint8_t ep, const uint8_t *data, uint32_t data_len
         } else {
             data_len = MIN(data_len, g_ch32_usbfs_udc.in_ep[ep_idx].ep_mps);
             USB_SET_TX_LEN(ep_idx, data_len);
-            memcpy(&g_ch32_usbfs_udc.ep_databuf[ep_idx - 1][64], data, data_len);
+            usb_memcpy(&g_ch32_usbfs_udc.ep_databuf[ep_idx - 1][64], data, data_len);
         }
         USB_SET_TX_CTRL(ep_idx, (USB_GET_TX_CTRL(ep_idx) & ~USBFS_UEP_T_RES_MASK) | USBFS_UEP_T_RES_ACK);
     }
@@ -309,7 +309,7 @@ void USBD_IRQHandler(void)
 
                         write_count = MIN(g_ch32_usbfs_udc.in_ep[ep_idx].xfer_len, g_ch32_usbfs_udc.in_ep[ep_idx].ep_mps);
                         USB_SET_TX_LEN(ep_idx, write_count);
-                        memcpy(&g_ch32_usbfs_udc.ep_databuf[ep_idx - 1][64], g_ch32_usbfs_udc.in_ep[ep_idx].xfer_buf, write_count);
+                        usb_memcpy(&g_ch32_usbfs_udc.ep_databuf[ep_idx - 1][64], g_ch32_usbfs_udc.in_ep[ep_idx].xfer_buf, write_count);
 
                         USB_SET_TX_CTRL(ep_idx, (USB_GET_TX_CTRL(ep_idx) & ~USBFS_UEP_T_RES_MASK) | USBFS_UEP_T_RES_ACK);
                     } else {
@@ -344,7 +344,7 @@ void USBD_IRQHandler(void)
                         USB_SET_RX_CTRL(ep_idx, (USB_GET_RX_CTRL(ep_idx) & ~USBFS_UEP_R_RES_MASK) | USBFS_UEP_R_RES_NAK);
                         read_count = USBFS_DEVICE->RX_LEN;
 
-                        memcpy(g_ch32_usbfs_udc.out_ep[ep_idx].xfer_buf, &g_ch32_usbfs_udc.ep_databuf[ep_idx - 1][0], read_count);
+                        usb_memcpy(g_ch32_usbfs_udc.out_ep[ep_idx].xfer_buf, &g_ch32_usbfs_udc.ep_databuf[ep_idx - 1][0], read_count);
 
                         g_ch32_usbfs_udc.out_ep[ep_idx].xfer_buf += read_count;
                         g_ch32_usbfs_udc.out_ep[ep_idx].actual_xfer_len += read_count;
@@ -382,7 +382,7 @@ void USBD_IRQHandler(void)
         ep0_tx_data_toggle = true;
         ep0_rx_data_toggle = true;
 
-        memset(&g_ch32_usbfs_udc, 0, sizeof(struct ch32_usbfs_udc));
+        usb_memset(&g_ch32_usbfs_udc, 0, sizeof(struct ch32_usbfs_udc));
         usbd_event_reset_handler();
         USB_SET_DMA(ep_idx, (uint32_t)&g_ch32_usbfs_udc.setup);
         USB_SET_RX_CTRL(ep_idx, USBFS_UEP_R_RES_ACK);

--- a/port/ch32/usb_dc_usbhs.c
+++ b/port/ch32/usb_dc_usbhs.c
@@ -368,7 +368,7 @@ void USBD_IRQHandler(void)
             epx_tx_data_toggle[ep_idx - 1] = false;
         }
 
-        memset(&g_ch32_usbhs_udc, 0, sizeof(struct ch32_usbhs_udc));
+        usb_memset(&g_ch32_usbhs_udc, 0, sizeof(struct ch32_usbhs_udc));
         usbd_event_reset_handler();
         USBHS_DEVICE->UEP0_DMA = (uint32_t)&g_ch32_usbhs_udc.setup;
         USBHS_DEVICE->UEP0_RX_CTRL = USBHS_EP_R_RES_ACK;

--- a/port/ch32/usb_hc_usbfs.c
+++ b/port/ch32/usb_hc_usbfs.c
@@ -468,7 +468,7 @@ __WEAK void usb_hc_low_level_init(void)
 
 int usb_hc_init(void)
 {
-    memset(&g_chusb_hcd, 0, sizeof(struct chusb_hcd));
+    usb_memset(&g_chusb_hcd, 0, sizeof(struct chusb_hcd));
 
     for (uint8_t i = 0; i < CONFIG_USBHOST_PIPE_NUM; i++) {
         g_chusb_hcd.pipe_pool[i][0].waitsem = usb_osal_sem_create(0);
@@ -533,7 +533,7 @@ int usbh_roothub_control(struct usb_setup_packet *setup, uint8_t *buf)
             case HUB_REQUEST_GET_DESCRIPTOR:
                 break;
             case HUB_REQUEST_GET_STATUS:
-                memset(buf, 0, 4);
+                usb_memset(buf, 0, 4);
                 break;
             default:
                 break;
@@ -608,7 +608,7 @@ int usbh_roothub_control(struct usb_setup_packet *setup, uint8_t *buf)
                     }
                 }
 
-                memcpy(buf, &status, 4);
+                usb_memcpy(buf, &status, 4);
                 break;
             default:
                 break;
@@ -649,7 +649,7 @@ int usbh_pipe_alloc(usbh_pipe_t *pipe, const struct usbh_endpoint_cfg *ep_cfg)
     /* store variables */
     waitsem = ppipe->waitsem;
 
-    memset(ppipe, 0, sizeof(struct chusb_pipe));
+    usb_memset(ppipe, 0, sizeof(struct chusb_pipe));
 
     ppipe->ep_addr = ep_cfg->ep_addr;
     ppipe->ep_type = ep_cfg->ep_type;

--- a/port/ch32/usb_hc_usbhs.c
+++ b/port/ch32/usb_hc_usbhs.c
@@ -531,7 +531,7 @@ __WEAK void usb_hc_low_level_init(void)
 
 int usb_hc_init(void)
 {
-    memset(&g_chusb_hcd, 0, sizeof(struct chusb_hcd));
+    usb_memset(&g_chusb_hcd, 0, sizeof(struct chusb_hcd));
 
     for (uint8_t i = 0; i < CONFIG_USBHOST_PIPE_NUM; i++) {
         g_chusb_hcd.pipe_pool[i][0].waitsem = usb_osal_sem_create(0);
@@ -593,7 +593,7 @@ int usbh_roothub_control(struct usb_setup_packet *setup, uint8_t *buf)
             case HUB_REQUEST_GET_DESCRIPTOR:
                 break;
             case HUB_REQUEST_GET_STATUS:
-                memset(buf, 0, 4);
+                usb_memset(buf, 0, 4);
                 break;
             default:
                 break;
@@ -668,7 +668,7 @@ int usbh_roothub_control(struct usb_setup_packet *setup, uint8_t *buf)
                     }
                 }
 
-                memcpy(buf, &status, 4);
+                usb_memcpy(buf, &status, 4);
                 break;
             default:
                 break;
@@ -709,7 +709,7 @@ int usbh_pipe_alloc(usbh_pipe_t *pipe, const struct usbh_endpoint_cfg *ep_cfg)
     /* store variables */
     waitsem = ppipe->waitsem;
 
-    memset(ppipe, 0, sizeof(struct chusb_pipe));
+    usb_memset(ppipe, 0, sizeof(struct chusb_pipe));
 
     ppipe->ep_addr = ep_cfg->ep_addr;
     ppipe->ep_type = ep_cfg->ep_type;

--- a/port/dwc2/usb_dc_dwc2.c
+++ b/port/dwc2/usb_dc_dwc2.c
@@ -118,9 +118,11 @@
 
 #define USB_RAM_SIZE 4096 /* define with minimum value*/
 
-#define CONFIG_USB_DWC2_DMA_ENABLE
+#ifndef CONFIG_USB_DWC2_DMA_ENABLE
+#define CONFIG_USB_DWC2_DMA_ENABLE      (1) /* default enable dma */
+#endif
 
-#ifdef CONFIG_USB_DWC2_DMA_ENABLE
+#if CONFIG_USB_DWC2_DMA_ENABLE
 #if defined(STM32F7) || defined(STM32H7)
 #warning "if you enable dcache,please add .nocacheble section in your sct or ld or icf"
 #endif
@@ -385,7 +387,7 @@ static void dwc2_ep0_start_read_setup(uint8_t *psetup)
     USB_OTG_OUTEP(0U)->DOEPTSIZ |= (3U * 8U);
     USB_OTG_OUTEP(0U)->DOEPTSIZ |= USB_OTG_DOEPTSIZ_STUPCNT;
 
-#ifdef CONFIG_USB_DWC2_DMA_ENABLE
+#if CONFIG_USB_DWC2_DMA_ENABLE
     USB_OTG_OUTEP(0U)->DOEPDMA = (uint32_t)psetup;
     /* EP enable */
     USB_OTG_OUTEP(0U)->DOEPCTL |= USB_OTG_DOEPCTL_EPENA | USB_OTG_DOEPCTL_USBAEP;
@@ -618,7 +620,7 @@ int usb_dc_init(void)
     /* Enable interrupts matching to the Device mode ONLY */
     USB_OTG_GLB->GINTMSK = USB_OTG_GINTMSK_USBRST | USB_OTG_GINTMSK_ENUMDNEM |
                            USB_OTG_GINTMSK_OEPINT | USB_OTG_GINTMSK_IEPINT;
-#ifdef CONFIG_USB_DWC2_DMA_ENABLE
+#if CONFIG_USB_DWC2_DMA_ENABLE
     USB_OTG_GLB->GAHBCFG |= USB_OTG_GAHBCFG_HBSTLEN_2;
     USB_OTG_GLB->GAHBCFG |= USB_OTG_GAHBCFG_DMAEN;
 #else
@@ -793,7 +795,7 @@ int usbd_ep_set_stall(const uint8_t ep)
         }
         USB_OTG_INEP(ep_idx)->DIEPCTL |= USB_OTG_DIEPCTL_STALL;
     }
-#ifdef CONFIG_USB_DWC2_DMA_ENABLE
+#if CONFIG_USB_DWC2_DMA_ENABLE
     if (ep_idx == 0) {
         dwc2_ep0_start_read_setup((uint8_t *)&g_dwc2_udc.setup);
     }
@@ -840,7 +842,7 @@ int usbd_ep_start_write(const uint8_t ep, const uint8_t *data, uint32_t data_len
     if (!g_dwc2_udc.in_ep[ep_idx].ep_enable) {
         return -2;
     }
-#ifdef CONFIG_USB_DWC2_DMA_ENABLE
+#if CONFIG_USB_DWC2_DMA_ENABLE
     if ((uint32_t)data & 0x03) {
         return -3;
     }
@@ -883,7 +885,7 @@ int usbd_ep_start_write(const uint8_t ep, const uint8_t *data, uint32_t data_len
         USB_OTG_INEP(ep_idx)->DIEPTSIZ |= (USB_OTG_DIEPTSIZ_MULCNT & (1U << 29));
     }
 
-#ifdef CONFIG_USB_DWC2_DMA_ENABLE
+#if CONFIG_USB_DWC2_DMA_ENABLE
     USB_OTG_INEP(ep_idx)->DIEPDMA = (uint32_t)data;
 
     USB_OTG_INEP(ep_idx)->DIEPCTL |= (USB_OTG_DIEPCTL_CNAK | USB_OTG_DIEPCTL_EPENA);
@@ -908,7 +910,7 @@ int usbd_ep_start_read(const uint8_t ep, uint8_t *data, uint32_t data_len)
     if (!g_dwc2_udc.out_ep[ep_idx].ep_enable) {
         return -2;
     }
-#ifdef CONFIG_USB_DWC2_DMA_ENABLE
+#if CONFIG_USB_DWC2_DMA_ENABLE
     if (((uint32_t)data) & 0x03) {
         return -3;
     }
@@ -941,7 +943,7 @@ int usbd_ep_start_read(const uint8_t ep, uint8_t *data, uint32_t data_len)
         USB_OTG_OUTEP(ep_idx)->DOEPTSIZ |= (USB_OTG_DOEPTSIZ_XFRSIZ & data_len);
     }
 
-#ifdef CONFIG_USB_DWC2_DMA_ENABLE
+#if CONFIG_USB_DWC2_DMA_ENABLE
     USB_OTG_OUTEP(ep_idx)->DOEPDMA = (uint32_t)data;
 #endif
     if (g_dwc2_udc.out_ep[ep_idx].ep_type == 0x01) {
@@ -966,7 +968,7 @@ void USBD_IRQHandler(void)
             return;
         }
 
-#ifndef CONFIG_USB_DWC2_DMA_ENABLE
+#if !CONFIG_USB_DWC2_DMA_ENABLE
         /* Handle RxQLevel Interrupt */
         if (gint_status & USB_OTG_GINTSTS_RXFLVL) {
             USB_MASK_INTERRUPT(USB_OTG_GLB, USB_OTG_GINTSTS_RXFLVL);

--- a/port/dwc2/usb_dc_dwc2.c
+++ b/port/dwc2/usb_dc_dwc2.c
@@ -536,7 +536,7 @@ int usb_dc_init(void)
 {
     int ret;
 
-    memset(&g_dwc2_udc, 0, sizeof(struct dwc2_udc));
+    usb_memset(&g_dwc2_udc, 0, sizeof(struct dwc2_udc));
 
     usb_dc_low_level_init();
 
@@ -1087,7 +1087,7 @@ void USBD_IRQHandler(void)
 
             USB_OTG_DEV->DIEPMSK = USB_OTG_DIEPMSK_XFRCM;
 
-            memset(&g_dwc2_udc, 0, sizeof(struct dwc2_udc));
+            usb_memset(&g_dwc2_udc, 0, sizeof(struct dwc2_udc));
             usbd_event_reset_handler();
             /* Start reading setup */
             dwc2_ep0_start_read_setup((uint8_t *)&g_dwc2_udc.setup);

--- a/port/dwc2/usb_hc_dwc2.c
+++ b/port/dwc2/usb_hc_dwc2.c
@@ -457,7 +457,7 @@ int usb_hc_init(void)
 {
     int ret;
 
-    memset(&g_dwc2_hcd, 0, sizeof(struct dwc2_hcd));
+    usb_memset(&g_dwc2_hcd, 0, sizeof(struct dwc2_hcd));
 
     for (uint8_t chidx = 0; chidx < CONFIG_USBHOST_PIPE_NUM; chidx++) {
         g_dwc2_hcd.pipe_pool[chidx].waitsem = usb_osal_sem_create(0);
@@ -575,7 +575,7 @@ int usbh_roothub_control(struct usb_setup_packet *setup, uint8_t *buf)
             case HUB_REQUEST_GET_DESCRIPTOR:
                 break;
             case HUB_REQUEST_GET_STATUS:
-                memset(buf, 0, 4);
+                usb_memset(buf, 0, 4);
                 break;
             default:
                 break;
@@ -668,7 +668,7 @@ int usbh_roothub_control(struct usb_setup_packet *setup, uint8_t *buf)
                     status |= (1 << HUB_PORT_FEATURE_POWER);
                 }
 
-                memcpy(buf, &status, 4);
+                usb_memcpy(buf, &status, 4);
                 break;
             default:
                 break;
@@ -705,7 +705,7 @@ int usbh_pipe_alloc(usbh_pipe_t *pipe, const struct usbh_endpoint_cfg *ep_cfg)
     /* store variables */
     waitsem = chan->waitsem;
 
-    memset(chan, 0, sizeof(struct dwc2_pipe));
+    usb_memset(chan, 0, sizeof(struct dwc2_pipe));
 
     chan->chidx = chidx;
     chan->ep_addr = ep_cfg->ep_addr;

--- a/port/ehci/usb_hc_ehci.c
+++ b/port/ehci/usb_hc_ehci.c
@@ -29,7 +29,7 @@ static struct ehci_qh_hw *ehci_qh_alloc(void)
         if (!g_ehci_hcd.ehci_qh_used[i]) {
             g_ehci_hcd.ehci_qh_used[i] = true;
             qh = &ehci_qh_pool[i];
-            memset(qh, 0, sizeof(struct ehci_qh_hw));
+            usb_memset(qh, 0, sizeof(struct ehci_qh_hw));
             qh->hw.hlp = QTD_LIST_END;
             qh->hw.overlay.next_qtd = QTD_LIST_END;
             qh->hw.overlay.alt_next_qtd = QTD_LIST_END;
@@ -56,7 +56,7 @@ static struct ehci_qtd_hw *ehci_qtd_alloc(void)
         if (!g_ehci_hcd.ehci_qtd_used[i]) {
             g_ehci_hcd.ehci_qtd_used[i] = true;
             qtd = &ehci_qtd_pool[i];
-            memset(qtd, 0, sizeof(struct ehci_qtd_hw));
+            usb_memset(qtd, 0, sizeof(struct ehci_qtd_hw));
             qtd->hw.next_qtd = QTD_LIST_END;
             qtd->hw.alt_next_qtd = QTD_LIST_END;
             qtd->hw.token = QTD_TOKEN_STATUS_HALTED;
@@ -685,7 +685,7 @@ int usb_hc_init(void)
     uint32_t timeout = 0;
     uint32_t regval;
 
-    memset(&g_ehci_hcd, 0, sizeof(struct ehci_hcd));
+    usb_memset(&g_ehci_hcd, 0, sizeof(struct ehci_hcd));
 
     if (sizeof(struct ehci_qh_hw) % 32) {
         USB_LOG_ERR("struct ehci_qh_hw is not align 32\r\n");
@@ -703,7 +703,7 @@ int usb_hc_init(void)
         pipe->waitsem = usb_osal_sem_create(0);
     }
 
-    memset(&g_async_qh_head, 0, sizeof(struct ehci_qh_hw));
+    usb_memset(&g_async_qh_head, 0, sizeof(struct ehci_qh_hw));
     g_async_qh_head.hw.hlp = QH_HLP_QH(&g_async_qh_head);
     g_async_qh_head.hw.epchar = QH_EPCHAR_H;
     g_async_qh_head.hw.overlay.next_qtd = QTD_LIST_END;
@@ -711,10 +711,10 @@ int usb_hc_init(void)
     g_async_qh_head.hw.overlay.token = QTD_TOKEN_STATUS_HALTED;
     g_async_qh_head.first_qtd = QTD_LIST_END;
 
-    memset(g_framelist, 0, sizeof(uint32_t) * CONFIG_USB_EHCI_FRAME_LIST_SIZE);
+    usb_memset(g_framelist, 0, sizeof(uint32_t) * CONFIG_USB_EHCI_FRAME_LIST_SIZE);
 
     for (int i = EHCI_PERIOIDIC_QH_NUM - 1; i >= 0; i--) {
-        memset(&g_periodic_qh_head[i], 0, sizeof(struct ehci_qh_hw));
+        usb_memset(&g_periodic_qh_head[i], 0, sizeof(struct ehci_qh_hw));
         g_periodic_qh_head[i].hw.hlp = QH_HLP_END;
         g_periodic_qh_head[i].hw.epchar = QH_EPCAPS_SSMASK(1);
         g_periodic_qh_head[i].hw.overlay.next_qtd = QTD_LIST_END;
@@ -849,7 +849,7 @@ int usbh_roothub_control(struct usb_setup_packet *setup, uint8_t *buf)
             case HUB_REQUEST_GET_DESCRIPTOR:
                 break;
             case HUB_REQUEST_GET_STATUS:
-                memset(buf, 0, 4);
+                usb_memset(buf, 0, 4);
                 break;
             default:
                 break;
@@ -950,7 +950,7 @@ int usbh_roothub_control(struct usb_setup_packet *setup, uint8_t *buf)
                 if (temp & EHCI_PORTSC_PP) {
                     status |= (1 << HUB_PORT_FEATURE_POWER);
                 }
-                memcpy(buf, &status, 4);
+                usb_memcpy(buf, &status, 4);
                 break;
             default:
                 break;
@@ -983,7 +983,7 @@ int usbh_pipe_alloc(usbh_pipe_t *pipe, const struct usbh_endpoint_cfg *ep_cfg)
     /* store variables */
     waitsem = ppipe->waitsem;
 
-    memset(ppipe, 0, sizeof(struct ehci_pipe));
+    usb_memset(ppipe, 0, sizeof(struct ehci_pipe));
 
     ppipe->ep_addr = ep_cfg->ep_addr;
     ppipe->ep_type = ep_cfg->ep_type;

--- a/port/fsdev/usb_dc_fsdev.c
+++ b/port/fsdev/usb_dc_fsdev.c
@@ -416,7 +416,7 @@ void USBD_IRQHandler(void)
         }
     }
     if (wIstr & USB_ISTR_RESET) {
-        memset(&g_fsdev_udc, 0, sizeof(struct fsdev_udc));
+        usb_memset(&g_fsdev_udc, 0, sizeof(struct fsdev_udc));
         g_fsdev_udc.pma_offset = USB_BTABLE_SIZE;
         usbd_event_reset_handler();
         /* start reading setup packet */

--- a/port/hpm/usb_dc_hpm.c
+++ b/port/hpm/usb_dc_hpm.c
@@ -60,7 +60,7 @@ int usb_dc_init(void)
 {
     usb_dc_low_level_init();
 
-    memset(&g_hpm_udc, 0, sizeof(struct hpm_udc));
+    usb_memset(&g_hpm_udc, 0, sizeof(struct hpm_udc));
     g_hpm_udc.handle = &usb_device_handle[0];
     g_hpm_udc.handle->regs = (USB_Type *)HPM_USB0_BASE;
     g_hpm_udc.handle->dcd_data = &_dcd_data;
@@ -219,8 +219,8 @@ void USBD_IRQHandler(void)
     }
 
     if (int_status & intr_reset) {
-        memset(g_hpm_udc.in_ep, 0, sizeof(struct hpm_ep_state) * USB_NUM_BIDIR_ENDPOINTS);
-        memset(g_hpm_udc.out_ep, 0, sizeof(struct hpm_ep_state) * USB_NUM_BIDIR_ENDPOINTS);
+        usb_memset(g_hpm_udc.in_ep, 0, sizeof(struct hpm_ep_state) * USB_NUM_BIDIR_ENDPOINTS);
+        usb_memset(g_hpm_udc.out_ep, 0, sizeof(struct hpm_ep_state) * USB_NUM_BIDIR_ENDPOINTS);
         usbd_event_reset_handler();
         usb_device_bus_reset(handle, 64);
     }

--- a/port/musb/usb_dc_musb.c
+++ b/port/musb/usb_dc_musb.c
@@ -804,7 +804,7 @@ void USBD_IRQHandler(void)
 
     /* Receive a reset signal from the USB bus */
     if (is & USB_IS_RESET) {
-        memset(&g_musb_udc, 0, sizeof(struct musb_udc));
+        usb_memset(&g_musb_udc, 0, sizeof(struct musb_udc));
         g_musb_udc.fifo_size_offset = USB_CTRL_EP_MPS;
         usbd_event_reset_handler();
         HWREGH(USB_BASE + MUSB_TXIE_OFFSET) = USB_TXIE_EP0;

--- a/port/musb/usb_hc_musb.c
+++ b/port/musb/usb_hc_musb.c
@@ -388,7 +388,7 @@ int usb_hc_init(void)
     uint8_t regval;
     uint32_t fifo_offset = 0;
 
-    memset(&g_musb_hcd, 0, sizeof(struct musb_hcd));
+    usb_memset(&g_musb_hcd, 0, sizeof(struct musb_hcd));
 
     for (uint8_t i = 0; i < CONFIG_USBHOST_PIPE_NUM; i++) {
         g_musb_hcd.pipe_pool[i][0].waitsem = usb_osal_sem_create(0);
@@ -467,7 +467,7 @@ int usbh_roothub_control(struct usb_setup_packet *setup, uint8_t *buf)
             case HUB_REQUEST_GET_DESCRIPTOR:
                 break;
             case HUB_REQUEST_GET_STATUS:
-                memset(buf, 0, 4);
+                usb_memset(buf, 0, 4);
                 break;
             default:
                 break;
@@ -542,7 +542,7 @@ int usbh_roothub_control(struct usb_setup_packet *setup, uint8_t *buf)
                     }
                 }
 
-                memcpy(buf, &status, 4);
+                usb_memcpy(buf, &status, 4);
                 break;
             default:
                 break;
@@ -586,7 +586,7 @@ int usbh_pipe_alloc(usbh_pipe_t *pipe, const struct usbh_endpoint_cfg *ep_cfg)
     /* store variables */
     waitsem = ppipe->waitsem;
 
-    memset(ppipe, 0, sizeof(struct musb_pipe));
+    usb_memset(ppipe, 0, sizeof(struct musb_pipe));
 
     ppipe->ep_addr = ep_cfg->ep_addr;
     ppipe->ep_type = ep_cfg->ep_type;

--- a/port/nrf5x/usb_dc_nrf5x.c
+++ b/port/nrf5x/usb_dc_nrf5x.c
@@ -392,8 +392,8 @@ int usbd_ep_start_write(const uint8_t ep, const uint8_t *data, uint32_t data_len
     if (!CHECK_ADD_IS_RAM(data))
     {
       /*!< Data is not in ram */
-      /*!< Memcpy data to ram */
-      memcpy(usb_dc_cfg.ep_in[ep_idx].ep_buffer, data, data_len);
+      /*!< usb_memcpy data to ram */
+      usb_memcpy(usb_dc_cfg.ep_in[ep_idx].ep_buffer, data, data_len);
       nrf_usbd_ep_easydma_set_tx(ep_idx, (uint32_t)usb_dc_cfg.ep_in[ep_idx].ep_buffer, data_len);
     }
     else
@@ -561,7 +561,7 @@ int usb_dc_init(void)
   /*!< dc init */
   usb_dc_low_level_pre_init();
 
-  memset(&usb_dc_cfg, 0, sizeof(usb_dc_cfg));
+  usb_memset(&usb_dc_cfg, 0, sizeof(usb_dc_cfg));
   /*!< Clear USB Event Interrupt */
   NRF_USBD->EVENTS_USBEVENT = 0;
   NRF_USBD->EVENTCAUSE |= NRF_USBD->EVENTCAUSE;

--- a/port/template/usb_dc.c
+++ b/port/template/usb_dc.c
@@ -35,7 +35,7 @@ __WEAK void usb_dc_low_level_deinit(void)
 
 int usb_dc_init(void)
 {
-    memset(&g_xxx_udc, 0, sizeof(struct xxx_udc));
+    usb_memset(&g_xxx_udc, 0, sizeof(struct xxx_udc));
 
     usb_dc_low_level_init();
     return 0;

--- a/port/template/usb_hc.c
+++ b/port/template/usb_hc.c
@@ -71,7 +71,7 @@ int usb_hc_init(void)
 {
     int ret;
 
-    memset(&g_dwc2_hcd, 0, sizeof(struct dwc2_hcd));
+    usb_memset(&g_dwc2_hcd, 0, sizeof(struct dwc2_hcd));
 
     for (uint8_t chidx = 0; chidx < CONFIG_USBHOST_PIPE_NUM; chidx++) {
         g_dwc2_hcd.pipe_pool[chidx].waitsem = usb_osal_sem_create(0);
@@ -120,7 +120,7 @@ int usbh_roothub_control(struct usb_setup_packet *setup, uint8_t *buf)
             case HUB_REQUEST_GET_DESCRIPTOR:
                 break;
             case HUB_REQUEST_GET_STATUS:
-                memset(buf, 0, 4);
+                usb_memset(buf, 0, 4);
                 break;
             default:
                 break;
@@ -176,7 +176,7 @@ int usbh_roothub_control(struct usb_setup_packet *setup, uint8_t *buf)
                     return -EPIPE;
                 }
 
-                memcpy(buf, &status, 4);
+                usb_memcpy(buf, &status, 4);
                 break;
             default:
                 break;
@@ -213,7 +213,7 @@ int usbh_pipe_alloc(usbh_pipe_t *pipe, const struct usbh_endpoint_cfg *ep_cfg)
     /* store variables */
     waitsem = chan->waitsem;
 
-    memset(chan, 0, sizeof(struct dwc2_pipe));
+    usb_memset(chan, 0, sizeof(struct dwc2_pipe));
 
     chan->ep_addr = ep_cfg->ep_addr;
     chan->ep_type = ep_cfg->ep_type;

--- a/port/xhci/usb_hc_xhci.c
+++ b/port/xhci/usb_hc_xhci.c
@@ -82,7 +82,7 @@ int usb_hc_init()
 
     usb_hc_low_level_init(); /* set gic and memp */
 
-    memset(xhci, 0, sizeof(*xhci));
+    usb_memset(xhci, 0, sizeof(*xhci));
     xhci->id = CONFIG_USBHOST_XHCI_ID;
     if (rc = xhci_probe(xhci, usb_hc_get_register_base()) != 0) {
         goto err_open; 
@@ -150,7 +150,7 @@ int usbh_roothub_control(struct usb_setup_packet *setup, uint8_t *buf)
                 break;
             case HUB_REQUEST_GET_STATUS:
 				USB_ASSERT(buf);
-                memset(buf, 0, 4);
+                usb_memset(buf, 0, 4);
                 break;
             default:
                 break;
@@ -286,7 +286,7 @@ int usbh_roothub_control(struct usb_setup_packet *setup, uint8_t *buf)
                     /* Port is not power off */
                     status |= (1 << HUB_PORT_FEATURE_POWER);
                 }
-                memcpy(buf, &status, 4);        
+                usb_memcpy(buf, &status, 4);        
                 break;
             default:
                 break;
@@ -341,7 +341,7 @@ int usbh_pipe_alloc(usbh_pipe_t *pipe, const struct usbh_endpoint_cfg *ep_cfg)
         return -ENOMEM;
     }
 
-    memset(ppipe, 0, sizeof(struct xhci_endpoint));
+    usb_memset(ppipe, 0, sizeof(struct xhci_endpoint));
 
     ppipe->waitsem = usb_osal_sem_create(0);
     ppipe->waiter = false;

--- a/port/xhci/xhci.c
+++ b/port/xhci/xhci.c
@@ -646,7 +646,7 @@ static int xhci_dcbaa_alloc ( struct xhci_host *xhci ) {
 		rc = -ENOMEM;
 		goto err_alloc;
 	}
-	memset ( xhci->dcbaa.context, 0, len );
+	usb_memset ( xhci->dcbaa.context, 0, len );
 
 	/* Program DCBAA pointer */
 	dcbaap =  (uintptr_t)( xhci->dcbaa.context );
@@ -696,7 +696,7 @@ static int xhci_scratchpad_alloc ( struct xhci_host *xhci ) {
 		rc = -ENOMEM;
 		goto err_alloc;
 	}
-	memset ( (void *)scratch->buffer, 0, buffer_len );
+	usb_memset ( (void *)scratch->buffer, 0, buffer_len );
 
 	/* Allocate scratchpad array */
 	array_len = ( scratch->count * sizeof ( scratch->array[0] ) );
@@ -748,7 +748,7 @@ static int xhci_command_alloc ( struct xhci_host *xhci ) {
     if (! xhci->cmds)
         goto err_ring_alloc;
 
-    memset(xhci->cmds, 0U, sizeof(*xhci->cmds));
+    usb_memset(xhci->cmds, 0U, sizeof(*xhci->cmds));
 
     xhci->cmds->lock = usb_osal_mutex_create();
     USB_ASSERT(xhci->cmds->lock);
@@ -790,7 +790,7 @@ static int xhci_event_alloc ( struct xhci_host *xhci ) {
 		goto err_alloc_trb;
 	}
 
-	memset(xhci->evts, 0U, sizeof(*xhci->evts));
+	usb_memset(xhci->evts, 0U, sizeof(*xhci->evts));
 
 	/* Allocate event ring segment table */
 	xhci->eseg = usb_align(XHCI_ALIGMENT, sizeof(*xhci->eseg)); /* event segment */
@@ -798,7 +798,7 @@ static int xhci_event_alloc ( struct xhci_host *xhci ) {
 		rc = -ENOMEM;
 		goto err_alloc_segment;
 	}
-	memset(xhci->eseg, 0U, sizeof(*xhci->eseg));
+	usb_memset(xhci->eseg, 0U, sizeof(*xhci->eseg));
     xhci->eseg->base = CPU_TO_LE64 ( ( xhci->evts ) );
     xhci->eseg->count = XHCI_RING_ITEMS; /* items of event ring TRB */
 
@@ -1326,7 +1326,7 @@ uint32_t xhci_root_speed ( struct xhci_host *xhci, uint8_t port ) {
  */
 static inline void xhci_trb_fill(struct xhci_ring *ring, union xhci_trb *trb) {
 	union xhci_trb *dst = &ring->ring[ring->nidx];
-	memcpy((void *)dst, (void *)trb, sizeof(*trb));
+	usb_memcpy((void *)dst, (void *)trb, sizeof(*trb));
 	dst->template.control |= (ring->cs ? XHCI_TRB_C : 0);
 	xhci_dump_trbs(dst, 1);
 }
@@ -1421,7 +1421,7 @@ static void xhci_abort ( struct xhci_host *xhci ) {
 	}
 
  	/* Reset the command ring control register */
-    memset(xhci->cmds->ring, 0U, XHCI_RING_ITEMS * sizeof(union xhci_trb));
+    usb_memset(xhci->cmds->ring, 0U, XHCI_RING_ITEMS * sizeof(union xhci_trb));
 	xhci_writeq ( xhci, ( (uint64_t)(uintptr_t)xhci->cmds | xhci->cmds->cs ), xhci->op + XHCI_OP_CRCR );
 }
 
@@ -1472,7 +1472,7 @@ static int xhci_nop ( struct xhci_host *xhci, struct xhci_endpoint *ep ) {
 	int rc;
 
 	/* Construct command */
-	memset ( nop, 0, sizeof ( *nop ) );
+	usb_memset ( nop, 0, sizeof ( *nop ) );
 	nop->flags = XHCI_TRB_IOC;
 	nop->type = XHCI_TRB_NOP_CMD;
 
@@ -1499,7 +1499,7 @@ static int xhci_enable_slot(struct xhci_host *xhci, struct xhci_endpoint *ep, un
 	int rc;
 
 	/* Construct command */
-	memset ( enable, 0, sizeof ( *enable ) );
+	usb_memset ( enable, 0, sizeof ( *enable ) );
 	enable->slot = type;
 	enable->type = XHCI_TRB_ENABLE_SLOT;
 
@@ -1533,7 +1533,7 @@ static int xhci_disable_slot ( struct xhci_host *xhci, struct xhci_endpoint *ep,
 	int rc;
 
 	/* Construct command */
-	memset ( disable, 0, sizeof ( *disable ) );
+	usb_memset ( disable, 0, sizeof ( *disable ) );
 	disable->type = XHCI_TRB_DISABLE_SLOT;
 	disable->slot = slot;
 
@@ -1577,13 +1577,13 @@ static int xhci_context ( struct xhci_host *xhci, struct xhci_slot *slot,
 		rc = -ENOMEM;
 		goto err_alloc;
 	}
-	memset ( input, 0, len );
+	usb_memset ( input, 0, len );
 
 	/* Populate input context */
 	populate ( xhci, slot, ep, input );
 
 	/* Construct command */
-	memset ( context, 0, sizeof ( *context ) );
+	usb_memset ( context, 0, sizeof ( *context ) );
 	context->type = type;
 	context->input = CPU_TO_LE64 ( ( input ) );
 	context->slot = slot->id;
@@ -1692,7 +1692,7 @@ int xhci_reset_endpoint ( struct xhci_host *xhci,
 	int rc;
 
 	/* Construct command */
-	memset ( reset, 0, sizeof ( *reset ) );
+	usb_memset ( reset, 0, sizeof ( *reset ) );
 	reset->slot = slot->id;
 	reset->endpoint = endpoint->ctx;
 	reset->type = XHCI_TRB_RESET_ENDPOINT;
@@ -1724,7 +1724,7 @@ static inline int xhci_stop_endpoint ( struct xhci_host *xhci,
 	int rc;
 
 	/* Construct command */
-	memset ( stop, 0, sizeof ( *stop ) );
+	usb_memset ( stop, 0, sizeof ( *stop ) );
 	stop->slot = slot->id;
 	stop->endpoint = endpoint->ctx;
 	stop->type = XHCI_TRB_STOP_ENDPOINT;
@@ -1824,7 +1824,7 @@ int xhci_device_open ( struct xhci_host *xhci, struct xhci_endpoint *ep, int *sl
 		rc = -ENOMEM;
 		goto err_alloc_context;
 	}
-	memset ( slot->context, 0, len );
+	usb_memset ( slot->context, 0, len );
 
 	/* Set device context base address */
 	USB_ASSERT ( xhci->dcbaa.context[id] == 0 );
@@ -2233,9 +2233,9 @@ void xhci_endpoint_message ( struct xhci_endpoint *ep,
 
 	/* Construct setup stage TRB */
 	setup = &(trb.setup);
-	memset ( setup, 0, sizeof ( *setup ) );
+	usb_memset ( setup, 0, sizeof ( *setup ) );
 
-	memcpy ( &setup->packet, packet, sizeof ( setup->packet ) );
+	usb_memcpy ( &setup->packet, packet, sizeof ( setup->packet ) );
 	setup->len = CPU_TO_LE32 ( sizeof ( *packet ) ); /* bit[16:0] trb transfer length, always 8 */
 	setup->flags = XHCI_TRB_IDT; /* bit[6] Immediate Data (IDT), parameters take effect */
 	setup->type = XHCI_TRB_SETUP; /* bit[15:10] trb type */
@@ -2250,7 +2250,7 @@ void xhci_endpoint_message ( struct xhci_endpoint *ep,
 	/* Construct data stage TRB, if applicable */
 	if (datalen > 0) {
 		data = &(trb.data);
-		memset ( data, 0, sizeof ( *data ) );
+		usb_memset ( data, 0, sizeof ( *data ) );
 
 		data->data = CPU_TO_LE64 ( data_buff );
 		data->len = CPU_TO_LE32 ( datalen );
@@ -2261,7 +2261,7 @@ void xhci_endpoint_message ( struct xhci_endpoint *ep,
 	}
 
 	status = &(trb.status);
-	memset ( status, 0, sizeof ( *status ) );
+	usb_memset ( status, 0, sizeof ( *status ) );
 	status->flags = XHCI_TRB_IOC;
 	status->type = XHCI_TRB_STATUS;
 	status->direction =
@@ -2309,7 +2309,7 @@ void xhci_endpoint_stream ( struct xhci_endpoint *ep,
 
 	/* Construct normal TRBs */
 	normal = &trb->normal;
-	memset ( normal, 0, sizeof ( *normal ) );
+	usb_memset ( normal, 0, sizeof ( *normal ) );
 	normal->data = CPU_TO_LE64 ( (uintptr_t)data_buff );
 	normal->len = CPU_TO_LE32 ( trb_len );
 	normal->type = XHCI_TRB_NORMAL;
@@ -2462,7 +2462,7 @@ static void xhci_transfer ( struct xhci_host *xhci,
 	}
 
 	/* Record completion */
-	memcpy(pending, trb, sizeof(*trb)); /* copy current trb to cmd/transfer ring */
+	usb_memcpy(pending, trb, sizeof(*trb)); /* copy current trb to cmd/transfer ring */
 	trans_ring->eidx = eidx;
 
 	/* Check for errors */
@@ -2529,7 +2529,7 @@ static void xhci_complete ( struct xhci_host *xhci,
 
 	/* Record completion */
 	USB_LOG_DBG("command-0x%x completed !!! \r\n", pending);
-	memcpy(pending, trb, sizeof(*trb)); /* copy current trb to cmd/transfer ring */
+	usb_memcpy(pending, trb, sizeof(*trb)); /* copy current trb to cmd/transfer ring */
 	cmd_ring->eidx = eidx;
 
 	USB_ASSERT(work_pipe);


### PR DESCRIPTION
1. For my chip, use compiler libc memcpy in interrupt will crash, so use a marco of memcpy and memset to use custom function.
2. dwc2 default enable use dma, but seems my chip's usb controller not support it, so change this marco logic.